### PR TITLE
VIT-115 Limit node connections and access to chain data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,6 +3806,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-node-authorization"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40338264aeaa8927153af5ac21b738a9f1463b4db2362a0f181a335fc1da873"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7878,6 +7894,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 name = "vitalam-node"
 version = "1.0.1"
 dependencies = [
+ "bs58",
  "frame-benchmarking",
  "frame-benchmarking-cli",
  "hex-literal",
@@ -7925,6 +7942,7 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-grandpa",
+ "pallet-node-authorization",
  "pallet-randomness-collective-flip",
  "pallet-simple-nft",
  "pallet-sudo",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ Note that if you want to reset the state of your chain (for example because you'
 
 This will delete your dev chain so that it can be started from scratch again.
 
+### Node Authorization
+The node uses the [node-authorization](https://docs.rs/pallet-node-authorization/3.0.0/pallet_node_authorization/index.html) pallet to manage a configurable set of nodes for a permissioned network. The pre-configured well-known network for `local` chain contains `Alice`, `Bob`, `Charlie` and `Eve`. A node will not peer with the rest of the network unless the owner (account) starts the node with a `node-key` that corresponds to their `PeerId` and `AccountId` saved in `wellKnownNodes` storage. The set of `PeerId`s is initially configured in [`GenesisConfig`](node/src/chain_spec.rs). For example, to run and peer `Alice` and `Bob`, call the following two commands:
+
+```bash
+./target/release/vitalam-node \
+--chain=local \
+--base-path /tmp/validator1 \
+--alice \
+--node-key 0000000000000000000000000000000000000000000000000000000000000001 \
+--port 30333 \
+--ws-port 9944 
+```
+
+```bash
+./target/release/vitalam-node \
+--chain=local \
+--base-path /tmp/validator2 \
+--bob \
+--node-key=0000000000000000000000000000000000000000000000000000000000000002 \
+--port 30334 \
+--ws-port 9945
+```
+
+For `dev` chain, the network only contains a node for `Alice` so other nodes will not peer unless added to the well-known network, either by editing `chain_spec.rs` or using [dispatchable calls](https://docs.rs/pallet-node-authorization/3.0.0/pallet_node_authorization/enum.Call.html) at runtime. Also see [example](https://digicatapult.atlassian.net/wiki/spaces/EN/pages/1738014910/Example).
+
 ### Calculating weights
 
 To calculate the weights for the `pallet_simple_nft` you first must ensure the node is built with the benchmarking feature enabled:

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,26 +23,27 @@ substrate-build-script-utils = '3.0.0'
 jsonrpc-core = '15.1.0'
 structopt = '0.3.8'
 hex-literal = "0.3.1"
+bs58 = "0.4.0"
 
-vitalam-node-runtime = { path='../runtime', version='1.0.0' }
+vitalam-node-runtime = { path = '../runtime', version = '1.0.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'
 frame-benchmarking-cli = '3.0.0'
 pallet-transaction-payment-rpc = '3.0.0'
 sc-basic-authorship = '0.9.0'
-sc-cli = { features=['wasmtime'], version='0.9.0' }
+sc-cli = { features = ['wasmtime'], version = '0.9.0' }
 sc-client-api = '3.0.0'
 sc-consensus = '0.9.0'
 sc-consensus-aura = '0.9.0'
-sc-executor = { features=['wasmtime'], version='0.9.0' }
+sc-executor = { features = ['wasmtime'], version = '0.9.0' }
 sc-finality-grandpa = '0.9.0'
 
 sc-keystore = '3.0.0'
 
 sc-rpc = '3.0.0'
 sc-rpc-api = '0.9.0'
-sc-service = { features=['wasmtime'], version='0.9.0' }
+sc-service = { features = ['wasmtime'], version = '0.9.0' }
 sc-transaction-pool = '3.0.0'
 sp-api = '3.0.0'
 sp-block-builder = '3.0.0'

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -157,8 +157,11 @@ pub fn vitalam_staging_testnet_config() -> Result<ChainSpec, String> {
     ];
 
     let endowed_accounts: Vec<AccountId> = vec![
+        // 5Fpk38Xk2eixKwtNRnUn1YTcUuKbgSmF8G2wgRoqGUmgtG1o
         hex!["a64ad684438ae298d875f66e24e4f98f2d4689e008d431534f5c6adffd1ea26b"].into(),
+        // 5DtQJtJurJbniRA1LaFu9JgoL5Myi4C29EBfqtoJpcoEydLp
         hex!["509cf0e9e9c49855cf888f9af6bd481174399d6fdbe4d43041e6ed8a960b6a2c"].into(),
+        // 5H8iVfXZ89B8eByqEdwdRYuVJReEeETnC24GdVXj4LjSg27z
         hex!["e03c4bcf92683e004bb95bfffef863e4ecf1c9a1fc661c5807ac48e22b060b20"].into(),
     ];
 
@@ -180,7 +183,98 @@ pub fn vitalam_staging_testnet_config() -> Result<ChainSpec, String> {
                 // Pre-funded accounts
                 endowed_accounts.iter().map(|k| k.clone()).collect(),
                 Some(NodeAuthorizationConfig {
-                    nodes: vec![], //TODO add staging peer IDs and accounts
+                    nodes: vec![
+                        (
+                            // stage bootnode
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWCVhZ8Hm496zf4sugFekVyZtuE98b1XuySQUxztNvAQY6")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[0].clone(),
+                        ),
+                        (
+                            // stage red
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWRSxrnHyBjePLXcNyCaJE31oWFpoya5PrsYb3DUHP5QW7")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[0].clone(),
+                        ),
+                        (
+                            // stage green
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWKZGsMiJvispaQgVk2PDjECbT1FFx7VVoEF91wzquSho7")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[0].clone(),
+                        ),
+                        (
+                            // stage blue
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWSbedmDP2M8odLSFEMshWzAu6Rc8Hq24rw9xq1s1eCJzy")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[0].clone(),
+                        ),
+                        (
+                            // stage2 red
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWDW6qHkgpnxzb5FPbSwRU3paUirLeiEbTHRBQ7VwfcciV")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[1].clone(),
+                        ),
+                        (
+                            // stage2 green
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWQ2ignqpwNmXM8gCBaesg7VCupLHkXkcrKge2yzvyiKL4")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[1].clone(),
+                        ),
+                        (
+                            // stage2 blue
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWFkrb3zMP5Gijk6MYWUShPMRTdXeox3z5ppr4HzKztjDe")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[1].clone(),
+                        ),
+                        (
+                            // stage3 red
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWG4N23D8Ny4ZPyqv4zBwJN3YGUtrhURP8ZUAkJTip14hK")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[2].clone(),
+                        ),
+                        (
+                            // stage3 green
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWN48NLTwN4gyjbaPYX1hzgmewGKN3iYAphh24NaZb5TWF")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[2].clone(),
+                        ),
+                        (
+                            // stage3 blue
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWHxeSevn6pdXCfaz13eEKPEgubZbt3W2mg3Lwaaa5HRpP")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            endowed_accounts[2].clone(),
+                        ),
+                    ],
                 }),
                 true,
             )

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -61,6 +61,16 @@ pub fn development_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
                 ],
+                Some(NodeAuthorizationConfig {
+                    nodes: vec![(
+                        OpaquePeerId(
+                            bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2")
+                                .into_vec()
+                                .unwrap(),
+                        ),
+                        get_account_id_from_seed::<sr25519::Public>("Alice"),
+                    )],
+                }),
                 true,
             )
         },
@@ -169,6 +179,9 @@ pub fn vitalam_staging_testnet_config() -> Result<ChainSpec, String> {
                 sudo_account.clone(),
                 // Pre-funded accounts
                 endowed_accounts.iter().map(|k| k.clone()).collect(),
+                Some(NodeAuthorizationConfig {
+                    nodes: vec![], //TODO add staging peer IDs and accounts
+                }),
                 true,
             )
         },
@@ -220,6 +233,34 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                     get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
                     get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
                 ],
+                Some(NodeAuthorizationConfig {
+                    nodes: vec![
+                        (
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            get_account_id_from_seed::<sr25519::Public>("Alice"),
+                        ),
+                        (
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            get_account_id_from_seed::<sr25519::Public>("Bob"),
+                        ),
+                        (
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                        ),
+                    ],
+                }),
                 true,
             )
         },
@@ -242,6 +283,7 @@ fn testnet_genesis(
     initial_authorities: Vec<(AuraId, GrandpaId)>,
     root_key: AccountId,
     endowed_accounts: Vec<AccountId>,
+    node_authorization_config: Option<NodeAuthorizationConfig>,
     _enable_println: bool,
 ) -> GenesisConfig {
     GenesisConfig {
@@ -264,6 +306,6 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: root_key,
         }),
-        pallet_node_authorization: Some(NodeAuthorizationConfig { nodes: vec![] }),
+        pallet_node_authorization: node_authorization_config,
     }
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,11 +1,12 @@
 use sc_service::ChainType;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_core::OpaquePeerId; // A struct wraps Vec<u8>, represents as our `PeerId`.
 use sp_core::{sr25519, Pair, Public};
 use sp_finality_grandpa::AuthorityId as GrandpaId;
 use sp_runtime::traits::{IdentifyAccount, Verify};
 use vitalam_node_runtime::{
-    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, Signature, SudoConfig, SystemConfig,
-    WASM_BINARY,
+    AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig, NodeAuthorizationConfig, Signature,
+    SudoConfig, SystemConfig, WASM_BINARY,
 };
 const DEFAULT_PROTOCOL_ID: &str = "vam";
 
@@ -263,5 +264,6 @@ fn testnet_genesis(
             // Assign network admin rights.
             key: root_key,
         }),
+        pallet_node_authorization: Some(NodeAuthorizationConfig { nodes: vec![] }),
     }
 }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -63,7 +63,12 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 ],
                 Some(NodeAuthorizationConfig {
                     nodes: vec![(
-                        OpaquePeerId(get_from_seed::<sr25519::Public>("Alice").to_vec()),
+                        //0000000000000000000000000000000000000000000000000000000000000001
+                        OpaquePeerId(
+                            bs58::decode("12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp")
+                                .into_vec()
+                                .unwrap(),
+                        ),
                         get_account_id_from_seed::<sr25519::Public>("Alice"),
                     )],
                 }),
@@ -326,16 +331,40 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                 Some(NodeAuthorizationConfig {
                     nodes: vec![
                         (
-                            OpaquePeerId(get_from_seed::<sr25519::Public>("Alice").to_vec()),
+                            // 0000000000000000000000000000000000000000000000000000000000000001
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
                             get_account_id_from_seed::<sr25519::Public>("Alice"),
                         ),
                         (
-                            OpaquePeerId(get_from_seed::<sr25519::Public>("Bob").to_vec()),
+                            // 0000000000000000000000000000000000000000000000000000000000000002
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWHdiAxVd8uMQR1hGWXccidmfCwLqcMpGwR6QcTP6QRMuD")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
                             get_account_id_from_seed::<sr25519::Public>("Bob"),
                         ),
                         (
-                            OpaquePeerId(get_from_seed::<sr25519::Public>("Charlie").to_vec()),
+                            // 0000000000000000000000000000000000000000000000000000000000000003
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWSCufgHzV4fCwRijfH2k3abrpAJxTKxEvN1FDuRXA2U9x")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
                             get_account_id_from_seed::<sr25519::Public>("Charlie"),
+                        ),
+                        (
+                            // 0000000000000000000000000000000000000000000000000000000000000004
+                            OpaquePeerId(
+                                bs58::decode("12D3KooWSsChzF81YDUKpe9Uk5AHV5oqAaXAcWNSPYgoLauUk4st")
+                                    .into_vec()
+                                    .unwrap(),
+                            ),
+                            get_account_id_from_seed::<sr25519::Public>("Eve"),
                         ),
                     ],
                 }),

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -63,11 +63,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
                 ],
                 Some(NodeAuthorizationConfig {
                     nodes: vec![(
-                        OpaquePeerId(
-                            bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2")
-                                .into_vec()
-                                .unwrap(),
-                        ),
+                        OpaquePeerId(get_from_seed::<sr25519::Public>("Alice").to_vec()),
                         get_account_id_from_seed::<sr25519::Public>("Alice"),
                     )],
                 }),
@@ -330,27 +326,15 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
                 Some(NodeAuthorizationConfig {
                     nodes: vec![
                         (
-                            OpaquePeerId(
-                                bs58::decode("12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2")
-                                    .into_vec()
-                                    .unwrap(),
-                            ),
+                            OpaquePeerId(get_from_seed::<sr25519::Public>("Alice").to_vec()),
                             get_account_id_from_seed::<sr25519::Public>("Alice"),
                         ),
                         (
-                            OpaquePeerId(
-                                bs58::decode("12D3KooWQYV9dGMFoRzNStwpXztXaBUjtPqi6aU76ZgUriHhKust")
-                                    .into_vec()
-                                    .unwrap(),
-                            ),
+                            OpaquePeerId(get_from_seed::<sr25519::Public>("Bob").to_vec()),
                             get_account_id_from_seed::<sr25519::Public>("Bob"),
                         ),
                         (
-                            OpaquePeerId(
-                                bs58::decode("12D3KooWJvyP3VJYymTqG7eH4PM5rN4T2agk5cdNCfNymAqwqcvZ")
-                                    .into_vec()
-                                    .unwrap(),
-                            ),
+                            OpaquePeerId(get_from_seed::<sr25519::Public>("Charlie").to_vec()),
                             get_account_id_from_seed::<sr25519::Public>("Charlie"),
                         ),
                     ],

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -20,38 +20,39 @@ package = 'parity-scale-codec'
 version = '2.0.0'
 
 [dependencies]
-hex-literal = { optional=true, version='0.3.1' }
+hex-literal = { optional = true, version = '0.3.1' }
 
-serde = { features=['derive'], optional=true, version='1.0.101' }
+serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
-pallet-simple-nft = { version='1.0.0', default-features=false, package='pallet-simple-nft', path='../pallets/simple-nft' }
+pallet-simple-nft = { version = '1.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 
-frame-benchmarking = { default-features=false, optional=true, version='3.0.0' }
-frame-executive = { default-features=false, version='3.0.0' }
-frame-support = { default-features=false, version='3.0.0' }
-frame-system = { default-features=false, version='3.0.0' }
-frame-system-benchmarking = { default-features=false, optional=true, version='3.0.0' }
-frame-system-rpc-runtime-api = { default-features=false, version='3.0.0' }
-pallet-aura = { default-features=false, version='3.0.0' }
-pallet-balances = { default-features=false, version='3.0.0' }
-pallet-grandpa = { default-features=false, version='3.0.0' }
-pallet-randomness-collective-flip = { default-features=false, version='3.0.0' }
-pallet-sudo = { default-features=false, version='3.0.0' }
-pallet-timestamp = { default-features=false, version='3.0.0' }
-pallet-transaction-payment = { default-features=false, version='3.0.0' }
-pallet-transaction-payment-rpc-runtime-api = { default-features=false, version='3.0.0' }
-sp-api = { default-features=false, version='3.0.0' }
-sp-block-builder = { default-features=false, version='3.0.0' }
-sp-consensus-aura = { default-features=false, version='0.9.0' }
-sp-core = { default-features=false, version='3.0.0' }
-sp-inherents = { default-features=false, version='3.0.0' }
-sp-offchain = { default-features=false, version='3.0.0' }
-sp-runtime = { default-features=false, version='3.0.0' }
-sp-session = { default-features=false, version='3.0.0' }
-sp-std = { default-features=false, version='3.0.0' }
-sp-transaction-pool = { default-features=false, version='3.0.0' }
-sp-version = { default-features=false, version='3.0.0' }
+frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
+frame-executive = { default-features = false, version = '3.0.0' }
+frame-support = { default-features = false, version = '3.0.0' }
+frame-system = { default-features = false, version = '3.0.0' }
+frame-system-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
+frame-system-rpc-runtime-api = { default-features = false, version = '3.0.0' }
+pallet-aura = { default-features = false, version = '3.0.0' }
+pallet-balances = { default-features = false, version = '3.0.0' }
+pallet-grandpa = { default-features = false, version = '3.0.0' }
+pallet-node-authorization = { default-features = false, version = '3.0.0' }
+pallet-randomness-collective-flip = { default-features = false, version = '3.0.0' }
+pallet-sudo = { default-features = false, version = '3.0.0' }
+pallet-timestamp = { default-features = false, version = '3.0.0' }
+pallet-transaction-payment = { default-features = false, version = '3.0.0' }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = '3.0.0' }
+sp-api = { default-features = false, version = '3.0.0' }
+sp-block-builder = { default-features = false, version = '3.0.0' }
+sp-consensus-aura = { default-features = false, version = '0.9.0' }
+sp-core = { default-features = false, version = '3.0.0' }
+sp-inherents = { default-features = false, version = '3.0.0' }
+sp-offchain = { default-features = false, version = '3.0.0' }
+sp-runtime = { default-features = false, version = '3.0.0' }
+sp-session = { default-features = false, version = '3.0.0' }
+sp-std = { default-features = false, version = '3.0.0' }
+sp-transaction-pool = { default-features = false, version = '3.0.0' }
+sp-version = { default-features = false, version = '3.0.0' }
 
 [features]
 default = ['std']
@@ -76,6 +77,7 @@ std = [
     'pallet-aura/std',
     'pallet-balances/std',
     'pallet-grandpa/std',
+    'pallet-node-authorization/std',
     'pallet-randomness-collective-flip/std',
     'pallet-sudo/std',
     'pallet-timestamp/std',

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 100,
+    spec_version: 102,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
+use frame_system::EnsureRoot;
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
@@ -255,6 +256,22 @@ impl pallet_sudo::Config for Runtime {
     type Call = Call;
 }
 
+parameter_types! {
+    pub const MaxWellKnownNodes: u32 = 8;
+    pub const MaxPeerIdLength: u32 = 128;
+}
+
+impl pallet_node_authorization::Config for Runtime {
+    type Event = Event;
+    type MaxWellKnownNodes = MaxWellKnownNodes;
+    type MaxPeerIdLength = MaxPeerIdLength;
+    type AddOrigin = EnsureRoot<AccountId>;
+    type RemoveOrigin = EnsureRoot<AccountId>;
+    type SwapOrigin = EnsureRoot<AccountId>;
+    type ResetOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = ();
+}
+
 /// Configure the template pallet in pallets/simple-nft.
 impl pallet_simple_nft::Config for Runtime {
     type Event = Event;
@@ -279,6 +296,7 @@ construct_runtime!(
         TransactionPayment: pallet_transaction_payment::{Module, Storage},
         Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
         SimpleNFTModule: pallet_simple_nft::{Module, Call, Storage, Event<T>},
+        NodeAuthorization: pallet_node_authorization::{Module, Call, Storage, Event<T>, Config<T>},
     }
 );
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -257,7 +257,7 @@ impl pallet_sudo::Config for Runtime {
 }
 
 parameter_types! {
-    pub const MaxWellKnownNodes: u32 = 8;
+    pub const MaxWellKnownNodes: u32 = 16;
     pub const MaxPeerIdLength: u32 = 128;
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 102,
+    spec_version: 101,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
We want to limit which nodes connect to other nodes on the chain to stop unknown nodes from accessing the chain and reading chain data. Substrate provide the node-authorization pallet for creating and managing a permissioned network of nodes.

The file changes cover the following steps:
- [x] Add [node-authorization](https://docs.rs/pallet-node-authorization/3.0.0/pallet_node_authorization/index.html) pallet.
- [x] Set pre-authorised well-known nodes in genesis config for each chain type.
```
dev
  - Alice

staging
  - stage (red/green/blue/bootnode)
  - stage2 (red/green/blue)
  - stage3 (red/green/blue)

local
  - Alice
  - Bob
  - Charlie 
  - Eve
```
- [x] Bump node version

The process for adding genesis config to a live chain (in this case adding an initial set of permissioned well-known nodes) is documented [here](https://digicatapult.atlassian.net/wiki/spaces/EN/pages/1736015886/Adding+genesis+config+to+a+live+chain).
The process for adding a new node, either as a well-known node or a sub-node, to an already permissioned chain with an existing set of well-known nodes is documented [here](https://digicatapult.atlassian.net/wiki/spaces/EN/pages/1722253361/Node+Authentication#Example).

