### PR TITLE
Multiple token roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,7 +7939,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "TokenMetadataValue": "MetadataValue",
   "Token": {
     "id": "TokenId",
-    "owner": "BTreeMap<RoleKey, AccountId>",
+    "roles": "BTreeMap<RoleKey, AccountId>",
     "creator": "AccountId",
     "created_at": "BlockNumber",
     "destroyed_at": "Option<BlockNumber>",

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Then you can run the benchmark tool with for example
 ./target/release/vitalam-node benchmark \
     --pallet 'pallet_simple_nft' \
     --extrinsic '*' \
+    --repeat 1000 \
     --output ./weights/
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     }
   },
   "Role": {
-    "_enum": ["Owner"]
+    "_enum": ["Admin", "ManufacturingEngineer", "ProcurementBuyer", "ProcurementPlanner", "Supplier"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -104,11 +104,12 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "PeerId": "Vec<u8>",
   "Key": "Vec<u8>",
   "TokenId": "u128",
+  "RoleKey": "Role",
   "TokenMetadataKey": "[u8; 32]",
   "TokenMetadataValue": "MetadataValue",
   "Token": {
     "id": "TokenId",
-    "owner": "AccountId",
+    "owner": "BTreeMap<RoleKey, AccountId>",
     "creator": "AccountId",
     "created_at": "BlockNumber",
     "destroyed_at": "Option<BlockNumber>",
@@ -120,15 +121,18 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "_enum": {
       "File": "Hash",
       "Literal": "[u8; 32]",
-      "None": "null",
-    },
+      "None": "null"
+    }
   },
+  "Role": {
+    "_enum": ["Owner"]
+  }
 }
 ```
 
 ### SimpleNFT pallet
 
-The `SimpleNFT` pallet exposes an extrinsic for minting/burning tokens and a storage format that allows their retrieval. All of the additional types listed above, apart from `PeerId`, are for the `SimpleNFT` pallet.
+The `SimpleNFT` pallet exposes an extrinsic for minting/burning tokens and a storage format that allows their retrieval.
 
 Note: The json object with types, described above, has been upgraded from `"Address": "AccountId", "LookupSource": "AccountId"` to `"Address": "MultiAddress", "LookupSource": "MultiAddress"` and it also needs to be used in conjunction with the new version of _PolkaDot JS_, **v4.7.2** or higher.
 
@@ -136,13 +140,13 @@ Two storage endpoints are then exposed under `SimpleNFT` for the id of the last 
 
 ```rust
 LastToken get(fn last_token): T::TokenId;
-TokensById get(fn tokens_by_id): map T::TokenId => Token<T::AccountId, T::TokenId, T::BlockNumber, T::TokenMetadataKey, T::TokenMetadataValue>;
+TokensById get(fn tokens_by_id): map T::TokenId => Token<T::AccountId, T::RoleKey, T::TokenId, T::BlockNumber, T::TokenMetadataKey, T::TokenMetadataValue>;
 ```
 
 Tokens can be minted/burnt by calling the following extrinsic under `SimpleNFT`:
 
 ```rust
-pub fn run_process(origin, inputs: Vec<T::TokenId>, outputs: Vec<(T::AccountId, BTreeMap<T::TokenMetadataKey, T::TokenMetadataValue>)> -> dispatch::DispatchResult { ... }
+pub fn run_process(origin, inputs: Vec<T::TokenId>, outputs: Vec<(BTreeMap<T::RoleKey, T::AccountId>, BTreeMap<T::TokenMetadataKey, T::TokenMetadataValue>)> -> dispatch::DispatchResult { ... }
 ```
 
 All of this functionality can be easily accessed using [https://polkadot.js.org/apps](https://polkadot.js.org/apps) against a running `dev` node. You will need to add a network endpoint of `ws://localhost:9944` under `Settings` and apply the above type configurations in the `Settings/Developer` tab.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.3.0'
+version = '2.4.0'
 
 [[bin]]
 name = 'vitalam-node'

--- a/pallets/simple-nft/src/benchmarking.rs
+++ b/pallets/simple-nft/src/benchmarking.rs
@@ -12,13 +12,15 @@ use crate::Module as SimpleNFT;
 const SEED: u32 = 0;
 
 fn add_nfts<T: Config>(r: u32) -> Result<(), &'static str> {
-    let owner: T::AccountId = account("owner", 0, SEED);
+    let account_id: T::AccountId = account("owner", 0, SEED);
+    let mut owner = BTreeMap::new();
     let mut metadata = BTreeMap::new();
+    owner.insert(T::RoleKey::default(), account_id.clone());
     metadata.insert(T::TokenMetadataKey::default(), T::TokenMetadataValue::default());
     // let _ = T::Currency::make_free_balance_be(&owner, BalanceOf::<T>::max_value());
 
     let outputs: Vec<_> = (0..r).map(|_| (owner.clone(), metadata.clone())).collect();
-    SimpleNFT::<T>::run_process(RawOrigin::Signed(owner.clone()).into(), Vec::new(), outputs)?;
+    SimpleNFT::<T>::run_process(RawOrigin::Signed(account_id.clone()).into(), Vec::new(), outputs)?;
 
     let expected_last_token = nth_token_id::<T>(r)?;
 
@@ -38,9 +40,17 @@ fn mk_inputs<T: Config>(i: u32) -> Result<Vec<T::TokenId>, &'static str> {
 
 fn mk_outputs<T: Config>(
     o: u32,
-) -> Result<Vec<(T::AccountId, BTreeMap<T::TokenMetadataKey, T::TokenMetadataValue>)>, &'static str> {
-    let owner: T::AccountId = account("owner", 0, SEED);
+) -> Result<
+    Vec<(
+        BTreeMap<T::RoleKey, T::AccountId>,
+        BTreeMap<T::TokenMetadataKey, T::TokenMetadataValue>,
+    )>,
+    &'static str,
+> {
+    let account_id: T::AccountId = account("owner", 0, SEED);
+    let mut owner = BTreeMap::new();
     let mut metadata = BTreeMap::new();
+    owner.insert(T::RoleKey::default(), account_id.clone());
     metadata.insert(T::TokenMetadataKey::default(), T::TokenMetadataValue::default());
     let outputs = (0..o).map(|_| (owner.clone(), metadata.clone())).collect::<Vec<_>>();
 

--- a/pallets/simple-nft/src/benchmarking.rs
+++ b/pallets/simple-nft/src/benchmarking.rs
@@ -13,13 +13,13 @@ const SEED: u32 = 0;
 
 fn add_nfts<T: Config>(r: u32) -> Result<(), &'static str> {
     let account_id: T::AccountId = account("owner", 0, SEED);
-    let mut owner = BTreeMap::new();
+    let mut roles = BTreeMap::new();
     let mut metadata = BTreeMap::new();
-    owner.insert(T::RoleKey::default(), account_id.clone());
+    roles.insert(T::RoleKey::default(), account_id.clone());
     metadata.insert(T::TokenMetadataKey::default(), T::TokenMetadataValue::default());
     // let _ = T::Currency::make_free_balance_be(&owner, BalanceOf::<T>::max_value());
 
-    let outputs: Vec<_> = (0..r).map(|_| (owner.clone(), metadata.clone())).collect();
+    let outputs: Vec<_> = (0..r).map(|_| (roles.clone(), metadata.clone())).collect();
     SimpleNFT::<T>::run_process(RawOrigin::Signed(account_id.clone()).into(), Vec::new(), outputs)?;
 
     let expected_last_token = nth_token_id::<T>(r)?;
@@ -48,11 +48,11 @@ fn mk_outputs<T: Config>(
     &'static str,
 > {
     let account_id: T::AccountId = account("owner", 0, SEED);
-    let mut owner = BTreeMap::new();
+    let mut roles = BTreeMap::new();
     let mut metadata = BTreeMap::new();
-    owner.insert(T::RoleKey::default(), account_id.clone());
+    roles.insert(T::RoleKey::default(), account_id.clone());
     metadata.insert(T::TokenMetadataKey::default(), T::TokenMetadataValue::default());
-    let outputs = (0..o).map(|_| (owner.clone(), metadata.clone())).collect::<Vec<_>>();
+    let outputs = (0..o).map(|_| (roles.clone(), metadata.clone())).collect::<Vec<_>>();
 
     Ok(outputs)
 }

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -100,9 +100,9 @@ pub mod pallet {
         NotOwned,
         /// Mutation was attempted on token that has already been burnt
         AlreadyBurnt,
-        /// Minting token attempted with too many metadata items
+        /// Token mint was attempted with too many metadata items
         TooManyMetadataItems,
-        /// Minting token attempted without setting a default role
+        /// Token mint was attempted without setting a default role
         NoDefaultRole,
     }
 

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -22,7 +22,7 @@ mod benchmarking;
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Token<AccountId, RoleKey, TokenId, BlockNumber, TokenMetadataKey: Ord, TokenMetadataValue> {
     id: TokenId,
-    owner: BTreeMap<RoleKey, AccountId>,
+    roles: BTreeMap<RoleKey, AccountId>,
     creator: AccountId,
     created_at: BlockNumber,
     destroyed_at: Option<BlockNumber>,
@@ -145,7 +145,7 @@ pub mod pallet {
             // check origin owns inputs and that inputs have not been burnt
             for id in inputs.iter() {
                 let token = <TokensById<T>>::get(id);
-                ensure!(token.owner[&T::RoleKey::default()] == sender, Error::<T>::NotOwned);
+                ensure!(token.roles[&T::RoleKey::default()] == sender, Error::<T>::NotOwned);
                 ensure!(token.children == None, Error::<T>::AlreadyBurnt);
             }
 
@@ -157,13 +157,13 @@ pub mod pallet {
             // Create new tokens getting a tuple of the last token created and the complete Vec of tokens created
             let (last, children) = outputs
                 .iter()
-                .fold((last, Vec::new()), |(last, children), (owner, metadata)| {
+                .fold((last, Vec::new()), |(last, children), (roles, metadata)| {
                     let next = _next_token(last);
                     <TokensById<T>>::insert(
                         next,
                         Token {
                             id: next,
-                            owner: owner.clone(),
+                            roles: roles.clone(),
                             creator: sender.clone(),
                             created_at: now,
                             destroyed_at: None,

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -100,8 +100,10 @@ pub mod pallet {
         NotOwned,
         /// Mutation was attempted on token that has already been burnt
         AlreadyBurnt,
-        /// Mutation was attempted with too many metadata items
+        /// Minting token attempted with too many metadata items
         TooManyMetadataItems,
+        /// Minting token attempted without setting a default role
+        NoDefaultRole,
     }
 
     // The pallet's dispatchable functions.
@@ -129,8 +131,11 @@ pub mod pallet {
 
             // INPUT VALIDATION
 
-            // check metadata count
             for output in outputs.iter() {
+                // check at least a default role has been set
+                ensure!(output.0.contains_key(&T::RoleKey::default()), Error::<T>::NoDefaultRole);
+
+                // check metadata count
                 ensure!(
                     output.1.len() <= T::MaxMetadataCount::get() as usize,
                     Error::<T>::TooManyMetadataItems

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -68,6 +68,7 @@ parameter_types! {
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
     Admin,
+    NotAdmin,
 }
 
 impl Default for Role {

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -67,12 +67,12 @@ parameter_types! {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
-    Owner,
+    Admin,
 }
 
 impl Default for Role {
     fn default() -> Self {
-        Role::Owner
+        Role::Admin
     }
 }
 

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -65,6 +65,17 @@ parameter_types! {
     pub const MaxMetadataCount: u32 = 3;
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
+pub enum Role {
+    Owner,
+}
+
+impl Default for Role {
+    fn default() -> Self {
+        Role::Owner
+    }
+}
+
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub enum MetadataValue {
     File(Hash),
@@ -82,6 +93,7 @@ impl pallet_simple_nft::Config for Test {
     type Event = Event;
 
     type TokenId = u64;
+    type RoleKey = Role;
     type TokenMetadataKey = u64;
     type TokenMetadataValue = MetadataValue;
 

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -136,6 +136,37 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
 }
 
 #[test]
+fn it_works_for_creating_token_with_multiple_roles() {
+    new_test_ext().execute_with(|| {
+        // create a token with no parents
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
+        let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
+        assert_ok!(SimpleNFTModule::run_process(
+            Origin::signed(1),
+            Vec::new(),
+            vec![(roles.clone(), metadata.clone())]
+        ));
+        // last token should be 1
+        assert_eq!(SimpleNFTModule::last_token(), 1);
+        // get the token
+        let token = SimpleNFTModule::tokens_by_id(1);
+        assert_eq!(
+            token,
+            Token {
+                id: 1,
+                roles: roles.clone(),
+                creator: 1,
+                created_at: 0,
+                destroyed_at: None,
+                metadata: metadata.clone(),
+                parents: Vec::new(),
+                children: None
+            }
+        );
+    });
+}
+
+#[test]
 fn it_works_for_creating_many_token() {
     new_test_ext().execute_with(|| {
         // create a token with no parents

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -11,12 +11,12 @@ use sp_std::iter::FromIterator;
 fn it_works_for_creating_token_with_file() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner.clone(), metadata.clone())]
+            vec![(roles.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -26,7 +26,7 @@ fn it_works_for_creating_token_with_file() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -42,12 +42,12 @@ fn it_works_for_creating_token_with_file() {
 fn it_works_for_creating_token_with_literal() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner.clone(), metadata.clone())]
+            vec![(roles.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -57,7 +57,7 @@ fn it_works_for_creating_token_with_literal() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -73,12 +73,12 @@ fn it_works_for_creating_token_with_literal() {
 fn it_works_for_creating_token_with_no_metadata_value() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner.clone(), metadata.clone())]
+            vec![(roles.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -88,7 +88,7 @@ fn it_works_for_creating_token_with_no_metadata_value() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -104,7 +104,7 @@ fn it_works_for_creating_token_with_no_metadata_value() {
 fn it_works_for_creating_token_with_multiple_metadata_items() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![
             (0, MetadataValue::File(H256::zero())),
             (1, MetadataValue::Literal([0])),
@@ -113,7 +113,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner.clone(), metadata.clone())]
+            vec![(roles.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -123,7 +123,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -139,7 +139,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
 fn it_works_for_creating_many_token() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
@@ -147,9 +147,9 @@ fn it_works_for_creating_many_token() {
             Origin::signed(1),
             Vec::new(),
             vec![
-                (owner.clone(), metadata0.clone()),
-                (owner.clone(), metadata1.clone()),
-                (owner.clone(), metadata2.clone())
+                (roles.clone(), metadata0.clone()),
+                (roles.clone(), metadata1.clone()),
+                (roles.clone(), metadata2.clone())
             ]
         ));
         // last token should be 3
@@ -160,7 +160,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -174,7 +174,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 2,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -188,7 +188,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 3,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -204,7 +204,7 @@ fn it_works_for_creating_many_token() {
 fn it_works_for_creating_many_token_with_varied_metadata() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None), (1, MetadataValue::File(H256::zero()))]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         let metadata2 = BTreeMap::from_iter(vec![(1, MetadataValue::Literal([0]))]);
@@ -212,9 +212,9 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             Origin::signed(1),
             Vec::new(),
             vec![
-                (owner.clone(), metadata0.clone()),
-                (owner.clone(), metadata1.clone()),
-                (owner.clone(), metadata2.clone())
+                (roles.clone(), metadata0.clone()),
+                (roles.clone(), metadata1.clone()),
+                (roles.clone(), metadata2.clone())
             ]
         ));
         // last token should be 3
@@ -225,7 +225,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -239,7 +239,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 2,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -253,7 +253,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 3,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -268,9 +268,9 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
 #[test]
 fn it_works_for_destroying_single_token() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata.clone())]).unwrap();
         // create a token with no parents
         assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()));
         // assert no more tokens were created
@@ -281,7 +281,7 @@ fn it_works_for_destroying_single_token() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -296,7 +296,7 @@ fn it_works_for_destroying_single_token() {
 #[test]
 fn it_works_for_destroying_many_tokens() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
@@ -304,9 +304,9 @@ fn it_works_for_destroying_many_tokens() {
             Origin::signed(1),
             Vec::new(),
             vec![
-                (owner.clone(), metadata0.clone()),
-                (owner.clone(), metadata1.clone()),
-                (owner.clone(), metadata2.clone()),
+                (roles.clone(), metadata0.clone()),
+                (roles.clone(), metadata1.clone()),
+                (roles.clone(), metadata2.clone()),
             ],
         )
         .unwrap();
@@ -324,7 +324,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 1,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -338,7 +338,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 2,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -352,7 +352,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 3,
-                owner: owner.clone(),
+                roles: roles.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -367,16 +367,16 @@ fn it_works_for_destroying_many_tokens() {
 #[test]
 fn it_works_for_creating_and_destroy_single_tokens() {
     new_test_ext().execute_with(|| {
-        let owner1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
-        let owner2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
+        let roles1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner1.clone(), metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles1.clone(), metadata0.clone())]).unwrap();
         // create a token with a parent
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             vec![1],
-            vec![(owner2.clone(), metadata1.clone())]
+            vec![(roles2.clone(), metadata1.clone())]
         ));
         // assert 1 more token was created
         assert_eq!(SimpleNFTModule::last_token(), 2);
@@ -386,7 +386,7 @@ fn it_works_for_creating_and_destroy_single_tokens() {
             token,
             Token {
                 id: 1,
-                owner: owner1.clone(),
+                roles: roles1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -400,7 +400,7 @@ fn it_works_for_creating_and_destroy_single_tokens() {
             token,
             Token {
                 id: 2,
-                owner: owner2.clone(),
+                roles: roles2.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -415,8 +415,8 @@ fn it_works_for_creating_and_destroy_single_tokens() {
 #[test]
 fn it_works_for_creating_and_destroy_many_tokens() {
     new_test_ext().execute_with(|| {
-        let owner1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
-        let owner2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
+        let roles1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
@@ -424,14 +424,14 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner1.clone(), metadata0.clone()), (owner1.clone(), metadata1.clone())],
+            vec![(roles1.clone(), metadata0.clone()), (roles1.clone(), metadata1.clone())],
         )
         .unwrap();
         // create a token with 2 parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             vec![1, 2],
-            vec![(owner1.clone(), metadata2.clone()), (owner2.clone(), metadata3.clone())]
+            vec![(roles1.clone(), metadata2.clone()), (roles2.clone(), metadata3.clone())]
         ));
         // assert 2 more tokens were created
         assert_eq!(SimpleNFTModule::last_token(), 4);
@@ -441,7 +441,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 1,
-                owner: owner1.clone(),
+                roles: roles1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -455,7 +455,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 2,
-                owner: owner1.clone(),
+                roles: roles1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -470,7 +470,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 3,
-                owner: owner1.clone(),
+                roles: roles1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -484,7 +484,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 4,
-                owner: owner2.clone(),
+                roles: roles2.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -499,9 +499,9 @@ fn it_works_for_creating_and_destroy_many_tokens() {
 #[test]
 fn it_fails_for_destroying_single_token_as_incorrect_role() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
@@ -519,9 +519,9 @@ fn it_fails_for_destroying_single_token_as_incorrect_role() {
 #[test]
 fn it_fails_for_destroying_single_token_as_other_signer() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
@@ -539,11 +539,11 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
 #[test]
 fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(2), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata1.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(2), Vec::new(), vec![(roles.clone(), metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata1.clone())]).unwrap();
         // get old token
         let token_1 = SimpleNFTModule::tokens_by_id(1);
         let token_2 = SimpleNFTModule::tokens_by_id(2);
@@ -564,16 +564,16 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
 #[test]
 fn it_fails_for_destroying_single_burnt_token() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata0.clone())]).unwrap();
         SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(1), vec![1], vec![(owner.clone(), metadata1.clone())]),
+            SimpleNFTModule::run_process(Origin::signed(1), vec![1], vec![(roles.clone(), metadata1.clone())]),
             Error::<Test>::AlreadyBurnt
         );
         // assert no more tokens were created
@@ -586,14 +586,14 @@ fn it_fails_for_destroying_single_burnt_token() {
 #[test]
 fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(owner.clone(), metadata0.clone()), (owner.clone(), metadata1.clone())],
+            vec![(roles.clone(), metadata0.clone()), (roles.clone(), metadata1.clone())],
         )
         .unwrap();
         SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
@@ -603,7 +603,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         let token_2 = SimpleNFTModule::tokens_by_id(2);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(1), vec![1, 2], vec![(owner.clone(), metadata2.clone())]),
+            SimpleNFTModule::run_process(Origin::signed(1), vec![1, 2], vec![(roles.clone(), metadata2.clone())]),
             Error::<Test>::AlreadyBurnt
         );
         // assert no more tokens were created
@@ -618,7 +618,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
 #[test]
 fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata_too_many = BTreeMap::from_iter(vec![
             (0, MetadataValue::None),
@@ -626,7 +626,7 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
             (2, MetadataValue::None),
             (3, MetadataValue::None),
         ]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata0.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to create token with too many metadata items
@@ -634,7 +634,7 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
             SimpleNFTModule::run_process(
                 Origin::signed(1),
                 Vec::new(),
-                vec![(owner.clone(), metadata_too_many.clone())]
+                vec![(roles.clone(), metadata_too_many.clone())]
             ),
             Error::<Test>::TooManyMetadataItems
         );
@@ -648,18 +648,18 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
 #[test]
 fn it_fails_for_creating_single_token_with_no_default_role() {
     new_test_ext().execute_with(|| {
-        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
-        let owner_empty = BTreeMap::new();
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles_empty = BTreeMap::new();
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(roles.clone(), metadata.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
-        // Try to create token without setting default role in owner
+        // Try to create token without setting default role in roles
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
                 Vec::new(),
-                vec![(owner_empty.clone(), metadata.clone())]
+                vec![(roles_empty.clone(), metadata.clone())]
             ),
             Error::<Test>::NoDefaultRole
         );

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -644,3 +644,28 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
         assert_eq!(token, SimpleNFTModule::tokens_by_id(1));
     });
 }
+
+#[test]
+fn it_fails_for_creating_single_token_with_no_default_role() {
+    new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let owner_empty = BTreeMap::new();
+        let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        // get old token
+        let token = SimpleNFTModule::tokens_by_id(1);
+        // Try to create token without setting default role in owner
+        assert_err!(
+            SimpleNFTModule::run_process(
+                Origin::signed(1),
+                Vec::new(),
+                vec![(owner_empty.clone(), metadata.clone())]
+            ),
+            Error::<Test>::NoDefaultRole
+        );
+        // assert no more tokens were created
+        assert_eq!(SimpleNFTModule::last_token(), 1);
+        // assert old token hasn't changed
+        assert_eq!(token, SimpleNFTModule::tokens_by_id(1));
+    });
+}

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -497,6 +497,26 @@ fn it_works_for_creating_and_destroy_many_tokens() {
 }
 
 #[test]
+fn it_fails_for_destroying_single_token_as_incorrect_role() {
+    new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
+        let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
+        // get old token
+        let token = SimpleNFTModule::tokens_by_id(1);
+        // Try to destroy token as incorrect user
+        assert_err!(
+            SimpleNFTModule::run_process(Origin::signed(2), vec![1], Vec::new()),
+            Error::<Test>::NotOwned
+        );
+        // assert no more tokens were created
+        assert_eq!(SimpleNFTModule::last_token(), 1);
+        // assert old token hasn't changed
+        assert_eq!(token, SimpleNFTModule::tokens_by_id(1));
+    });
+}
+
+#[test]
 fn it_fails_for_destroying_single_token_as_other_signer() {
     new_test_ext().execute_with(|| {
         let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -11,11 +11,12 @@ use sp_std::iter::FromIterator;
 fn it_works_for_creating_token_with_file() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata.clone())]
+            vec![(owner.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -25,7 +26,7 @@ fn it_works_for_creating_token_with_file() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -41,11 +42,12 @@ fn it_works_for_creating_token_with_file() {
 fn it_works_for_creating_token_with_literal() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata.clone())]
+            vec![(owner.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -55,7 +57,7 @@ fn it_works_for_creating_token_with_literal() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -71,11 +73,12 @@ fn it_works_for_creating_token_with_literal() {
 fn it_works_for_creating_token_with_no_metadata_value() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata.clone())]
+            vec![(owner.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -85,7 +88,7 @@ fn it_works_for_creating_token_with_no_metadata_value() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -101,6 +104,7 @@ fn it_works_for_creating_token_with_no_metadata_value() {
 fn it_works_for_creating_token_with_multiple_metadata_items() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![
             (0, MetadataValue::File(H256::zero())),
             (1, MetadataValue::Literal([0])),
@@ -109,7 +113,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata.clone())]
+            vec![(owner.clone(), metadata.clone())]
         ));
         // last token should be 1
         assert_eq!(SimpleNFTModule::last_token(), 1);
@@ -119,7 +123,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -135,13 +139,18 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
 fn it_works_for_creating_many_token() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata0.clone()), (1, metadata1.clone()), (1, metadata2.clone())]
+            vec![
+                (owner.clone(), metadata0.clone()),
+                (owner.clone(), metadata1.clone()),
+                (owner.clone(), metadata2.clone())
+            ]
         ));
         // last token should be 3
         assert_eq!(SimpleNFTModule::last_token(), 3);
@@ -151,7 +160,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -165,7 +174,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 2,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -179,7 +188,7 @@ fn it_works_for_creating_many_token() {
             token,
             Token {
                 id: 3,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -195,13 +204,18 @@ fn it_works_for_creating_many_token() {
 fn it_works_for_creating_many_token_with_varied_metadata() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None), (1, MetadataValue::File(H256::zero()))]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         let metadata2 = BTreeMap::from_iter(vec![(1, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata0.clone()), (1, metadata1.clone()), (1, metadata2.clone())]
+            vec![
+                (owner.clone(), metadata0.clone()),
+                (owner.clone(), metadata1.clone()),
+                (owner.clone(), metadata2.clone())
+            ]
         ));
         // last token should be 3
         assert_eq!(SimpleNFTModule::last_token(), 3);
@@ -211,7 +225,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -225,7 +239,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 2,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -239,7 +253,7 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
             token,
             Token {
                 id: 3,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -254,8 +268,9 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
 #[test]
 fn it_works_for_destroying_single_token() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
         // create a token with no parents
         assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()));
         // assert no more tokens were created
@@ -266,7 +281,7 @@ fn it_works_for_destroying_single_token() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -281,13 +296,18 @@ fn it_works_for_destroying_single_token() {
 #[test]
 fn it_works_for_destroying_many_tokens() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata0.clone()), (1, metadata1.clone()), (1, metadata2.clone())],
+            vec![
+                (owner.clone(), metadata0.clone()),
+                (owner.clone(), metadata1.clone()),
+                (owner.clone(), metadata2.clone()),
+            ],
         )
         .unwrap();
         // create a token with no parents
@@ -304,7 +324,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -318,7 +338,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 2,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -332,7 +352,7 @@ fn it_works_for_destroying_many_tokens() {
             token,
             Token {
                 id: 3,
-                owner: 1,
+                owner: owner.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -347,14 +367,16 @@ fn it_works_for_destroying_many_tokens() {
 #[test]
 fn it_works_for_creating_and_destroy_single_tokens() {
     new_test_ext().execute_with(|| {
+        let owner1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let owner2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner1.clone(), metadata0.clone())]).unwrap();
         // create a token with a parent
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             vec![1],
-            vec![(2, metadata1.clone())]
+            vec![(owner2.clone(), metadata1.clone())]
         ));
         // assert 1 more token was created
         assert_eq!(SimpleNFTModule::last_token(), 2);
@@ -364,7 +386,7 @@ fn it_works_for_creating_and_destroy_single_tokens() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -378,7 +400,7 @@ fn it_works_for_creating_and_destroy_single_tokens() {
             token,
             Token {
                 id: 2,
-                owner: 2,
+                owner: owner2.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -393,6 +415,8 @@ fn it_works_for_creating_and_destroy_single_tokens() {
 #[test]
 fn it_works_for_creating_and_destroy_many_tokens() {
     new_test_ext().execute_with(|| {
+        let owner1 = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let owner2 = BTreeMap::from_iter(vec![(Default::default(), 2)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
@@ -400,14 +424,14 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata0.clone()), (1, metadata1.clone())],
+            vec![(owner1.clone(), metadata0.clone()), (owner1.clone(), metadata1.clone())],
         )
         .unwrap();
         // create a token with 2 parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
             vec![1, 2],
-            vec![(1, metadata2.clone()), (2, metadata3.clone())]
+            vec![(owner1.clone(), metadata2.clone()), (owner2.clone(), metadata3.clone())]
         ));
         // assert 2 more tokens were created
         assert_eq!(SimpleNFTModule::last_token(), 4);
@@ -417,7 +441,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 1,
-                owner: 1,
+                owner: owner1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -431,7 +455,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 2,
-                owner: 1,
+                owner: owner1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: Some(0),
@@ -446,7 +470,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 3,
-                owner: 1,
+                owner: owner1.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -460,7 +484,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
             token,
             Token {
                 id: 4,
-                owner: 2,
+                owner: owner2.clone(),
                 creator: 1,
                 created_at: 0,
                 destroyed_at: None,
@@ -475,8 +499,9 @@ fn it_works_for_creating_and_destroy_many_tokens() {
 #[test]
 fn it_fails_for_destroying_single_token_as_other_signer() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
@@ -494,10 +519,11 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
 #[test]
 fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(2), Vec::new(), vec![(1, metadata0.clone())]).unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata1.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(2), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata1.clone())]).unwrap();
         // get old token
         let token_1 = SimpleNFTModule::tokens_by_id(1);
         let token_2 = SimpleNFTModule::tokens_by_id(2);
@@ -518,15 +544,16 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
 #[test]
 fn it_fails_for_destroying_single_burnt_token() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
         SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(1), vec![1], vec![(1, metadata1.clone())]),
+            SimpleNFTModule::run_process(Origin::signed(1), vec![1], vec![(owner.clone(), metadata1.clone())]),
             Error::<Test>::AlreadyBurnt
         );
         // assert no more tokens were created
@@ -539,13 +566,14 @@ fn it_fails_for_destroying_single_burnt_token() {
 #[test]
 fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
             Vec::new(),
-            vec![(1, metadata0.clone()), (1, metadata1.clone())],
+            vec![(owner.clone(), metadata0.clone()), (owner.clone(), metadata1.clone())],
         )
         .unwrap();
         SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
@@ -555,7 +583,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         let token_2 = SimpleNFTModule::tokens_by_id(2);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(1), vec![1, 2], vec![(1, metadata2.clone())]),
+            SimpleNFTModule::run_process(Origin::signed(1), vec![1, 2], vec![(owner.clone(), metadata2.clone())]),
             Error::<Test>::AlreadyBurnt
         );
         // assert no more tokens were created
@@ -570,6 +598,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
 #[test]
 fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
     new_test_ext().execute_with(|| {
+        let owner = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata0 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         let metadata_too_many = BTreeMap::from_iter(vec![
             (0, MetadataValue::None),
@@ -577,12 +606,16 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
             (2, MetadataValue::None),
             (3, MetadataValue::None),
         ]);
-        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata0.clone())]).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(owner.clone(), metadata0.clone())]).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to create token with too many metadata items
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(1), Vec::new(), vec![(1, metadata_too_many.clone())]),
+            SimpleNFTModule::run_process(
+                Origin::signed(1),
+                Vec::new(),
+                vec![(owner.clone(), metadata_too_many.clone())]
+            ),
             Error::<Test>::TooManyMetadataItems
         );
         // assert no more tokens were created

--- a/pallets/simple-nft/src/weights.rs
+++ b/pallets/simple-nft/src/weights.rs
@@ -28,16 +28,16 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn run_process(i: usize, o: usize) -> Weight {
-        (0 as Weight)
-            // Standard Error: 3_008_000
-            .saturating_add((14_764_000 as Weight).saturating_mul(i as Weight))
-            // Standard Error: 3_008_000
-            .saturating_add((10_806_000 as Weight).saturating_mul(o as Weight))
-            .saturating_add(T::DbWeight::get().reads(1 as Weight))
-            .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(T::DbWeight::get().writes(1 as Weight))
-            .saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
-            .saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(o as Weight)))
+		(14_049_000 as Weight)
+			// Standard Error: 7_000
+			.saturating_add((12_902_000 as Weight).saturating_mul(i as Weight))
+			// Standard Error: 7_000
+			.saturating_add((5_897_000 as Weight).saturating_mul(o as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(T::DbWeight::get().writes(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(i as Weight)))
+			.saturating_add(T::DbWeight::get().writes((1 as Weight).saturating_mul(o as Weight)))
     }
 }
 

--- a/pallets/simple-nft/src/weights.rs
+++ b/pallets/simple-nft/src/weights.rs
@@ -28,9 +28,11 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn run_process(i: usize, o: usize) -> Weight {
-        (104_267_000 as Weight)
-            // Standard Error: 6_647_000
-            .saturating_add((13_768_000 as Weight).saturating_mul(i as Weight))
+        (0 as Weight)
+            // Standard Error: 3_008_000
+            .saturating_add((14_764_000 as Weight).saturating_mul(i as Weight))
+            // Standard Error: 3_008_000
+            .saturating_add((10_806_000 as Weight).saturating_mul(o as Weight))
             .saturating_add(T::DbWeight::get().reads(1 as Weight))
             .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(T::DbWeight::get().writes(1 as Weight))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,11 +293,11 @@ parameter_types! {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
-    Admin,
-    ManufacturingEngineer,
-    ProcurementBuyer,
-    ProcurementPlanner,
-    Supplier,
+    Admin = 0,
+    ManufacturingEngineer = 1,
+    ProcurementBuyer = 2,
+    ProcurementPlanner = 3,
+    Supplier = 4,
 }
 
 impl Default for Role {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -291,6 +291,17 @@ parameter_types! {
     pub const MaxMetadataCount: u32 = 16;
 }
 
+#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
+pub enum Role {
+    Owner,
+}
+
+impl Default for Role {
+    fn default() -> Self {
+        Role::Owner
+    }
+}
+
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
 pub enum MetadataValue {
     File(Hash),
@@ -308,6 +319,7 @@ impl Default for MetadataValue {
 impl pallet_simple_nft::Config for Runtime {
     type Event = Event;
     type TokenId = u128;
+    type RoleKey = Role;
     type TokenMetadataKey = [u8; 32];
     type TokenMetadataValue = MetadataValue;
     type WeightInfo = pallet_simple_nft::weights::SubstrateWeight<Runtime>;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,12 +293,16 @@ parameter_types! {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
-    Owner,
+    Admin,
+    ManufacturingEngineer,
+    ProcurementBuyer,
+    ProcurementPlanner,
+    Supplier,
 }
 
 impl Default for Role {
     fn default() -> Self {
-        Role::Owner
+        Role::Admin
     }
 }
 


### PR DESCRIPTION
Represent multiple roles on a token beyond `owner` so we can more easily understand which accounts it's allowable to transfer a token to. In the future this will allow multiple parties to make the next statement on an asset (token) without having to transact back and forth.

`owner: AccountId` -> `roles: BTreeMap<RoleKey, AccountId>`

At runtime, `RoleKey` has type of `Role` which represents an enumeration of the sensible roles (agreed with Luca) we anticipate for the project.
```
pub enum Role {
    Admin, //Default
    ManufacturingEngineer,
    ProcurementBuyer,
    ProcurementPlanner,
    Supplier,
}
```

For now, `run_process` checks that the sender `AccountId` matches the `AccountId` for the default role (`Admin`) of all `input` tokens, more nuance will be added to this in the future.

- [x] version -> `2.4.0`
- [x] `owner: AccountId` ->  `roles: BTreeMap<RoleKey, AccountId>`
- [x] add RoleKey + Role enum
- [x] validate that at least the default role is set on every token 
- [x] update tests to cover new enum
- [x] benchmarking
- [x] README
