### PR TITLE
Create minideb docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
   build-docker-build-base:
     name: Build Docker Build Base Image
     runs-on: ubuntu-latest
-    needs: [get-version]
+    needs: [get-version, build-release]
     steps:
     - uses: actions/checkout@master
     - name: Setup QEMU
@@ -193,7 +193,7 @@ jobs:
   build-release:
     name: Build release
     runs-on: ubuntu-latest
-    needs: [build-docker, get-version]
+    needs: [get-version]
     if: ${{ needs.get-version.outputs.is_new_version == 'true' }}
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,7 +7939,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bs58",
  "frame-benchmarking",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,27 @@
-# syntax=docker/dockerfile:1.2
+FROM bitnami/minideb:bullseye AS setup
 
-# build base that sets up common dependencies of the build
-FROM rust:alpine as build-base
+RUN apt-get update && apt-get install -y \
+  curl
+  #libgcc
+  # libstdc++
 
-RUN apk add --no-cache \
-  clang clang-dev clang-libs pkgconfig bearssl-dev git \
-  gcc make g++ linux-headers protobuf protobuf-dev musl-dev
+RUN mkdir /tmp/vitalam-node/
+WORKDIR /tmp/vitalam-node/
 
-RUN set -ex; \
-  wget https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 -P /; \
-  mv /fetch_linux_amd64 /fetch; \
-  chmod +x /fetch; \
-  /fetch --repo="https://github.com/mozilla/sccache" --tag="~>0.2.15" --release-asset="^sccache-v[0-9.]*-x86_64-unknown-linux-musl.tar.gz$" /; \
-  tar -xvf /sccache-v*-x86_64-unknown-linux-musl.tar.gz -C /; \
-  mv /sccache-v*-x86_64-unknown-linux-musl/sccache /sccache; \
-  rm -rf /sccache-v*-x86_64-unknown-linux-musl /sccache-v*-x86_64-unknown-linux-musl.tar.gz /fetch; \
-  chmod +x /sccache;
+RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
 
-WORKDIR /build
-ARG RUST_TOOLCHAIN=nightly-2021-11-09
-RUN rustup install $RUST_TOOLCHAIN && \
-  rustup target add wasm32-unknown-unknown --toolchain $RUST_TOOLCHAIN
+RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="v2.5.1" --release-asset="vitalam-node-v2.5.1-x86_64-unknown-linux-gnu.tar.gz" ./ \
+  && tar -xzf ./vitalam-node-v2.5.1-x86_64-unknown-linux-gnu.tar.gz 
 
-FROM build-base as build
+FROM bitnami/minideb:bullseye AS runtime
 
-COPY . .
-
-RUN --mount=type=cache,mode=0755,id=sccache,target=/cache \
-    --mount=type=tmpfs,target=/build/target \
-    PROTOC=$(which protoc) \
-    PROTOC_INCLUDE=/usr/include \
-    RUSTFLAGS=-Ctarget-feature=-crt-static \
-    RUSTC_WRAPPER=/sccache \
-    SCCACHE_DIR=/cache \
-    SCCACHE_IDLE_TIMEOUT=0 \
-    cargo build --release && \
-    cp /build/target/release/vitalam-node /vitalam-node
-
-# build the runtime image that will actually contain the final built executable
-
-FROM alpine:3.12 AS runtime
-
-RUN apk update
-RUN apk add libgcc libstdc++
+RUN apt-get update \
+  && apt-get install -y \
+  build-essential \
+  libgcc-10-dev
 
 RUN mkdir /vitalam-node /data
-COPY --from=build /vitalam-node /vitalam-node
+COPY --from=setup /tmp/vitalam-node /vitalam-node/
 
 WORKDIR /vitalam-node
 
@@ -53,4 +29,4 @@ CMD /vitalam-node/vitalam-node
 
 EXPOSE 30333 9933 9944
 
-# docker run -it --rm -h node-0 -e IDENTITY=dev -e WS=true -p 30333:30333 -p 9944:9944 -p 9933:9933 vitalam-substrate-node ./run.sh
+# #docker run -it --rm -h node-0 -e IDENTITY=dev -e WS=true -p 30333:30333 -p 9944:9944 -p 9933:9933 vitalam-substrate-node ./run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@ FROM bitnami/minideb:bullseye AS setup
 
 RUN install_packages curl ca-certificates
 
-WORKDIR /tmp/vitalam-node/
+WORKDIR /tmp/
 
 RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
 
 ARG VITALAM_VERSION=latest
 
 RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="${VITALAM_VERSION}" --release-asset="vitalam-node-.*-x86_64-unknown-linux-gnu.tar.gz" ./ \
-  && tar -xzf ./vitalam-node-*-x86_64-unknown-linux-gnu.tar.gz 
+  && mkdir ./vitalam-node \
+  && tar -xzf ./vitalam-node-*-x86_64-unknown-linux-gnu.tar.gz -C ./vitalam-node
 
 FROM bitnami/minideb:bullseye AS runtime
 
@@ -21,8 +22,8 @@ COPY --from=setup /tmp/vitalam-node /vitalam-node/
 
 WORKDIR /vitalam-node
 
-CMD /vitalam-node/vitalam-node
+ENTRYPOINT [ "/vitalam-node/vitalam-node" ]
 
 EXPOSE 30333 9933 9944
 
-# #docker run -it --rm -h node-0 -e IDENTITY=dev -e WS=true -p 30333:30333 -p 9944:9944 -p 9933:9933 vitalam-substrate-node ./run.sh
+#docker run -it --rm -h node-0 -e IDENTITY=dev -e WS=true -p 30333:30333 -p 9944:9944 -p 9933:9933 vitalam-substrate-node ./run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM bitnami/minideb:bullseye AS setup
 
-RUN apt-get update && apt-get install -y \
-  curl
-  #libgcc
-  # libstdc++
+RUN install_packages curl ca-certificates
 
-RUN mkdir /tmp/vitalam-node/
 WORKDIR /tmp/vitalam-node/
 
 RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
@@ -15,12 +11,10 @@ RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="v2.5.1"
 
 FROM bitnami/minideb:bullseye AS runtime
 
-RUN apt-get update \
-  && apt-get install -y \
-  build-essential \
-  libgcc-10-dev
+RUN install_packages libgcc-10-dev
 
 RUN mkdir /vitalam-node /data
+
 COPY --from=setup /tmp/vitalam-node /vitalam-node/
 
 WORKDIR /vitalam-node

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,3 @@ WORKDIR /vitalam-node
 ENTRYPOINT [ "/vitalam-node/vitalam-node" ]
 
 EXPOSE 30333 9933 9944
-
-#docker run -it --rm -h node-0 -e IDENTITY=dev -e WS=true -p 30333:30333 -p 9944:9944 -p 9933:9933 vitalam-substrate-node ./run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ WORKDIR /tmp/vitalam-node/
 
 RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
 
-ARG VITALAM_VERSION
+ARG VITALAM_VERSION=latest
 
-RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="${VITALAM_VERSION}" --release-asset="vitalam-node-${VITALAM_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ./ \
-  && tar -xzf ./vitalam-node-${VITALAM_VERSION}-x86_64-unknown-linux-gnu.tar.gz 
+RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="${VITALAM_VERSION}" --release-asset="vitalam-node-.*-x86_64-unknown-linux-gnu.tar.gz" ./ \
+  && tar -xzf ./vitalam-node-*-x86_64-unknown-linux-gnu.tar.gz 
 
 FROM bitnami/minideb:bullseye AS runtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ WORKDIR /tmp/vitalam-node/
 
 RUN curl -L https://github.com/gruntwork-io/fetch/releases/download/v0.4.2/fetch_linux_amd64 --output ./fetch && chmod +x ./fetch
 
-RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="v2.5.1" --release-asset="vitalam-node-v2.5.1-x86_64-unknown-linux-gnu.tar.gz" ./ \
-  && tar -xzf ./vitalam-node-v2.5.1-x86_64-unknown-linux-gnu.tar.gz 
+ARG VITALAM_VERSION
+
+RUN ./fetch --repo="https://github.com/digicatapult/vitalam-node" --tag="${VITALAM_VERSION}" --release-asset="vitalam-node-${VITALAM_VERSION}-x86_64-unknown-linux-gnu.tar.gz" ./ \
+  && tar -xzf ./vitalam-node-${VITALAM_VERSION}-x86_64-unknown-linux-gnu.tar.gz 
 
 FROM bitnami/minideb:bullseye AS runtime
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.5.1'
+version = '2.5.2'
 
 [[bin]]
 name = 'vitalam-node'


### PR DESCRIPTION
## Summary
A new docker file that builds and image using pre-compiled binaries.
- [x] Create dockerfile that uses minideb and precompiled binary
- [x] Modify the workflow to build docker after compiling the binary

## Motivation
Our docker builds are very slow, so we are considering a replacement with a simpler build that downloads pre-compiled artefacts.

## Describe alternatives you've considered
- ☑️ Docker build time and rust compilation optimisations
- ☑️ Caching for rust compilation

## Additional context
  ```
▶ docker run -it --rm vitalam-node:minideb          11:30:31
2022-01-12 11:30:36 VITALam Node    
2022-01-12 11:30:36 ✌️  version 2.5.1-7b7d8d4-x86_64-linux-gnu    
2022-01-12 11:30:36 ❤️  by Digital Catapult <https://www.digicatapult.org.uk>, 2020-2022    
2022-01-12 11:30:36 📋 Chain specification: VITALam    
2022-01-12 11:30:36 🏷 Node name: gifted-earth-7985    
2022-01-12 11:30:36 👤 Role: FULL    
2022-01-12 11:30:36 💾 Database: RocksDb at /root/.local/share/vitalam-node/chains/vitalam/db    
2022-01-12 11:30:36 ⛓  Native runtime: vitalam-node-201 (vitalam-node-1.tx1.au1)    
2022-01-12 11:30:36 🔨 Initializing Genesis block/state (state: 0xf6e9…35fc, header-hash: 0xc80e…dcc5)    
2022-01-12 11:30:36 👴 Loading GRANDPA authority set from genesis on what appears to be first startup.    
2022-01-12 11:30:36 ⏱  Loaded block-time = 6000 milliseconds from genesis on first-launch    
2022-01-12 11:30:36 🏷 Local node identity is: 12D3KooWJhzDQeWzRrRDZMZ9f5NtQgPFXptfhZuYj6Kd9g8786Ji    
2022-01-12 11:30:36 📦 Highest known block at #0    
2022-01-12 11:30:36 〽️ Prometheus server started at 127.0.0.1:9615    
2022-01-12 11:30:36 Listening for new connections on 127.0.0.1:9944.    
2022-01-12 11:30:41 💤 Idle (0 peers), best: #0 (0xc80e…dcc5), finalized #0 (0xc80e…dcc5), ⬇ 0 ⬆ 0    
2022-01-12 11:30:46 💤 Idle (0 peers), best: #0 (0xc80e…dcc5), finalized #0 (0xc80e…dcc5), ⬇ 0 ⬆ 0  
```