### PR TITLE
Add TokenId to MetadataValue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-simple-nft"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7939,7 +7939,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "vitalam-node-runtime"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "_enum": {
       "File": "Hash",
       "Literal": "[u8; 32]",
+      "TokenId": "TokenId",
       "None": "null"
     }
   },

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.5.1'
+version = '2.6.0'
 
 [[bin]]
 name = 'vitalam-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-vitalam-node-runtime = { path = '../runtime', version = '2.0.1' }
+vitalam-node-runtime = { path = '../runtime', version = '2.1.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/simple-nft/Cargo.toml
+++ b/pallets/simple-nft/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-simple-nft'
-version = "2.0.0"
+version = "2.1.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -62,7 +62,7 @@ impl system::Config for Test {
 }
 
 parameter_types! {
-    pub const MaxMetadataCount: u32 = 3;
+    pub const MaxMetadataCount: u32 = 4;
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
@@ -78,13 +78,14 @@ impl Default for Role {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
-pub enum MetadataValue {
+pub enum MetadataValue<TokenId> {
     File(Hash),
     Literal([u8; 1]),
+    TokenId(TokenId),
     None,
 }
 
-impl Default for MetadataValue {
+impl<T> Default for MetadataValue<T> {
     fn default() -> Self {
         MetadataValue::None
     }
@@ -96,7 +97,7 @@ impl pallet_simple_nft::Config for Test {
     type TokenId = u64;
     type RoleKey = Role;
     type TokenMetadataKey = u64;
-    type TokenMetadataValue = MetadataValue;
+    type TokenMetadataValue = MetadataValue<Self::TokenId>;
 
     type WeightInfo = ();
 

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -80,6 +80,42 @@ fn it_works_for_creating_token_with_literal() {
 }
 
 #[test]
+fn it_works_for_creating_token_with_token_id_in_metadata() {
+    new_test_ext().execute_with(|| {
+        // create a token with no parents
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::TokenId(0))]);
+        assert_ok!(SimpleNFTModule::run_process(
+            Origin::signed(1),
+            Vec::new(),
+            vec![Output {
+                roles: roles.clone(),
+                metadata: metadata.clone(),
+                parent_index: None
+            }]
+        ));
+        // last token should be 1
+        assert_eq!(SimpleNFTModule::last_token(), 1);
+        // get the token
+        let token = SimpleNFTModule::tokens_by_id(1);
+        assert_eq!(
+            token,
+            Token {
+                id: 1,
+                original_id: 1,
+                roles: roles.clone(),
+                creator: 1,
+                created_at: 0,
+                destroyed_at: None,
+                metadata: metadata.clone(),
+                parents: Vec::new(),
+                children: None
+            }
+        );
+    });
+}
+
+#[test]
 fn it_works_for_creating_token_with_no_metadata_value() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
@@ -123,7 +159,8 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
         let metadata = BTreeMap::from_iter(vec![
             (0, MetadataValue::File(H256::zero())),
             (1, MetadataValue::Literal([0])),
-            (2, MetadataValue::None),
+            (2, MetadataValue::TokenId(0)),
+            (3, MetadataValue::None),
         ]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
@@ -930,6 +967,7 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
             (1, MetadataValue::None),
             (2, MetadataValue::None),
             (3, MetadataValue::None),
+            (4, MetadataValue::None),
         ]);
         SimpleNFTModule::run_process(
             Origin::signed(1),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node-runtime'
-version = '2.0.1'
+version = '2.1.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -25,7 +25,7 @@ hex-literal = { optional = true, version = '0.3.1' }
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
-pallet-simple-nft = { version = '2.0.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
+pallet-simple-nft = { version = '2.1.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 201,
+    spec_version: 210,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -307,13 +307,14 @@ impl Default for Role {
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
-pub enum MetadataValue {
+pub enum MetadataValue<TokenId> {
     File(Hash),
     Literal([u8; 32]),
+    TokenId(TokenId),
     None,
 }
 
-impl Default for MetadataValue {
+impl <T>Default for MetadataValue<T> {
     fn default() -> Self {
         MetadataValue::None
     }
@@ -325,7 +326,7 @@ impl pallet_simple_nft::Config for Runtime {
     type TokenId = u128;
     type RoleKey = Role;
     type TokenMetadataKey = [u8; 32];
-    type TokenMetadataValue = MetadataValue;
+    type TokenMetadataValue = MetadataValue<Self::TokenId>;
     type WeightInfo = pallet_simple_nft::weights::SubstrateWeight<Runtime>;
     type MaxMetadataCount = MaxMetadataCount;
 }


### PR DESCRIPTION
Makes it possible for metadata to be of the existing `TokenId` type.


- [x] add `TokenId` to the MetadataValue enum in the runtime
- [x] add `TokenId` to the MetadataValue enum in the mock
- [x] add pallet test and change a couple of others to include examples of `TokenId` metadata
- [x] version bumps
