### PR TITLE
Use correct build target name from new image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           RUST_TOOLCHAIN=${{ needs.get-version.outputs.toolchain }}
         file: ./Dockerfile
         platforms: linux/amd64
-        target: build-base
+        target: setup
     - name: Move cache
       env:
         CACHE_NEW: ${{ runner.temp }}/docker-buildx-cache-new


### PR DESCRIPTION
The new docker build workflow needs a small fix for the new dockerfile, due to name changes.

Questions for possible changes that we can include to tidy up the workflow:
- Remove sscache on line 108?
- Remove buildkit cache on line 119?
