### PR TITLE
Set the vitalam version build arg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,7 @@ jobs:
         context: .
         build-args: |
           RUST_TOOLCHAIN=${{ needs.get-version.outputs.toolchain }}
+          VITALAM_VERSION=${{ needs.get-version.outputs.version }}
         file: ./Dockerfile
         platforms: linux/amd64
         tags: |


### PR DESCRIPTION
**Problem**
The vitalam version needs to be passed as a build arg to the docker image compilation, otherwise the build can't specify the tag to download assets from.

**Solution**
Set the build-arg so that the vitalam version is set when compiling the dockerfile