### PR TITLE
Use demo roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,7 +7939,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.6.2"
+version = "2.7.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "vitalam-node-runtime"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     }
   },
   "Role": {
-    "_enum": ["Admin", "ManufacturingEngineer", "ProcurementBuyer", "ProcurementPlanner", "Supplier"]
+    "_enum": ["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]
   }
 }
 ```

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.6.2'
+version = '2.7.0'
 
 [[bin]]
 name = 'vitalam-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-vitalam-node-runtime = { path = '../runtime', version = '2.1.0' }
+vitalam-node-runtime = { path = '../runtime', version = '2.2.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/simple-nft/src/mock.rs
+++ b/pallets/simple-nft/src/mock.rs
@@ -67,13 +67,13 @@ parameter_types! {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
-    Admin,
-    NotAdmin,
+    Owner,
+    NotOwner,
 }
 
 impl Default for Role {
     fn default() -> Self {
-        Role::Admin
+        Role::Owner
     }
 }
 

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -196,7 +196,7 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
 fn it_works_for_creating_token_with_multiple_roles() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotOwner, 2)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
@@ -688,7 +688,7 @@ fn it_works_for_creating_and_destroy_many_tokens() {
 #[test]
 fn it_fails_for_destroying_single_token_as_incorrect_role() {
     new_test_ext().execute_with(|| {
-        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotAdmin, 2)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotOwner, 2)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node-runtime'
-version = '2.1.0'
+version = '2.2.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -293,16 +293,18 @@ parameter_types! {
 
 #[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
 pub enum Role {
-    Admin = 0,
-    ManufacturingEngineer = 1,
-    ProcurementBuyer = 2,
-    ProcurementPlanner = 3,
-    Supplier = 4,
+    Owner = 0,
+    Customer = 1,
+    AdditiveManufacturer = 2,
+    Laboratory = 3,
+    Buyer = 4,
+    Supplier = 5,
+    Reviewer = 6,
 }
 
 impl Default for Role {
     fn default() -> Self {
-        Role::Admin
+        Role::Owner
     }
 }
 
@@ -314,7 +316,7 @@ pub enum MetadataValue<TokenId> {
     None,
 }
 
-impl <T>Default for MetadataValue<T> {
+impl<T> Default for MetadataValue<T> {
     fn default() -> Self {
         MetadataValue::None
     }


### PR DESCRIPTION
Change the node roles enum to include all the roles we expect to use in our VITALam + INTELI demos. Default role `Admin` -> `Owner`

Roles:
`["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]`