### PR TITLE
Replace rather than update latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,19 @@ jobs:
           generate_release_notes: true
           files: |
             ${{ runner.temp }}/artefacts/vitalam-node-${{ needs.get-version.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz
+      - name: Delete release latest
+        if: ${{ needs.get-version.outputs.is_prerelease != 'true' }}
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo } = context.repo
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: 'tags/latest' })
+            }
+            catch (err) {
+              if (err.status !== 422) throw err
+            }   
       - name: Build release latest
         if: ${{ needs.get-version.outputs.is_prerelease != 'true' }}
         uses: softprops/action-gh-release@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7939,7 +7939,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "bs58",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.7.0'
+version = '2.7.1'
 
 [[bin]]
 name = 'vitalam-node'


### PR DESCRIPTION
Uses [github-script](https://github.com/actions/github-script) to delete `tags/latest` so we get a new `latest` release that matches our most recent release.
