### PR TITLE
First stab at the process validation pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7956,7 +7956,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.7.1"
+version = "2.8.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3837,6 +3837,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-process-validation"
+version = "1.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "vitalam-pallet-traits",
+]
+
+[[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,6 +3916,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
+ "vitalam-pallet-traits",
 ]
 
 [[package]]
@@ -7991,6 +8008,7 @@ dependencies = [
  "pallet-grandpa",
  "pallet-membership",
  "pallet-node-authorization",
+ "pallet-process-validation",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-simple-nft",
@@ -8013,6 +8031,15 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
+]
+
+[[package]]
+name = "vitalam-pallet-traits"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-simple-nft"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "TokenMetadataValue": "MetadataValue",
   "Token": {
     "id": "TokenId",
+    "original_id": "TokenId",
     "roles": "BTreeMap<RoleKey, AccountId>",
     "creator": "AccountId",
     "created_at": "BlockNumber",
@@ -133,6 +134,17 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   },
   "Role": {
     "_enum": ["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]
+  },
+  "ProcessIdentifier": "[u8; 32]",
+  "Process": {
+    "status": "ProcessStatus",
+    "restrictions": "Vec<Restriction>"
+  },
+  "ProcessStatus": {
+    "_enum": ["Disabled", "Enabled"]
+  },
+  "Restriction": {
+    "_enum": ["None"]
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "_enum": ["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]
   },
   "ProcessIdentifier": "[u8; 32]",
+  "ProcessVersion": "u32",
   "Process": {
     "status": "ProcessStatus",
     "restrictions": "Vec<Restriction>"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.7.1'
+version = '2.8.0'
 
 [[bin]]
 name = 'vitalam-node'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -45,5 +45,6 @@ std = [
     'frame-system/std',
     'frame-benchmarking/std',
     'sp-std/std',
+    'vitalam-pallet-traits/std',
 ]
 runtime-benchmarks = ['frame-benchmarking']

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-description = 'A FRAME pallet for validating something.... TODO'
+description = 'A FRAME pallet for storing and evaluating process validation restrictions'
 edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
-description = 'A FRAME pallet for handling non-fungible tokens'
+description = 'A FRAME pallet for validating something.... TODO'
 edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
-name = 'pallet-simple-nft'
-version = "2.1.0"
+name = 'pallet-process-validation'
+version = "1.0.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/benchmarking.rs
+++ b/pallets/process-validation/src/benchmarking.rs
@@ -1,0 +1,25 @@
+// ! Benchmarking setup for pallet-template
+
+use super::*;
+
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
+use frame_system::RawOrigin;
+use sp_std::{boxed::Box, vec, vec::Vec};
+
+#[allow(unused)]
+use crate::Module as ProcessValidation;
+
+// TODO implement benchmarking
+benchmarks! {
+  create_process {
+  }: _(RawOrigin::Root)
+  verify {
+  }
+
+  disable_process {
+  }: _(RawOrigin::Root)
+  verify {
+  }
+}
+
+impl_benchmark_test_suite!(ProcessValidation, crate::mock::new_test_ext(), crate::mock::Test,);

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -46,6 +46,7 @@ pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
+    use sp_runtime::traits::AtLeast32Bit;
 
     /// The pallet's configuration trait.
     #[pallet::config]
@@ -55,6 +56,7 @@ pub mod pallet {
 
         // The primary identifier for a process (i.e. it's name)
         type ProcessIdentifier: Parameter;
+        type ProcessVersion: Parameter + AtLeast32Bit;
 
         // Origins for calling these extrinsics. For now these are expected to be root
         type CreateProcessOrigin: EnsureOrigin<Self::Origin>;
@@ -83,7 +85,7 @@ pub mod pallet {
         Blake2_128Concat,
         T::ProcessIdentifier,
         Blake2_128Concat,
-        u32,
+        T::ProcessVersion,
         Process,
         ValueQuery
     >;
@@ -130,11 +132,12 @@ pub mod pallet {
 
 impl<T: Config> ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue> for Pallet<T> {
     type ProcessIdentifier = T::ProcessIdentifier;
+    type ProcessVersion = T::ProcessVersion;
 
     // TODO: implement lookup of process and checking of restrictions
     fn validate_process(
         _id: T::ProcessIdentifier,
-        _version: u32,
+        _version: T::ProcessVersion,
         _sender: T::AccountId,
         _inputs: &Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
         _outputs: &Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>) -> bool {

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -1,0 +1,143 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use codec::{Decode, Encode};
+pub use pallet::*;
+use sp_std::prelude::*;
+
+use vitalam_pallet_traits::{ProcessIO, ProcessValidator};
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(feature = "runtime-benchmarks")]
+mod benchmarking;
+
+// import the restrictions module where all our restriction types are defined
+mod restrictions;
+use restrictions::{Restriction};
+
+#[derive(Encode, Decode, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum ProcessStatus {
+    Disabled,
+    Enabled
+}
+
+impl Default for ProcessStatus {
+    fn default() -> Self {
+        ProcessStatus::Disabled
+    }
+}
+
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct Process {
+    status: ProcessStatus,
+    restrictions: Vec<Restriction>
+}
+
+pub mod weights;
+
+pub use weights::WeightInfo;
+
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    /// The pallet's configuration trait.
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The overarching event type.
+        type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
+        // The primary identifier for a process (i.e. it's name)
+        type ProcessIdentifier: Parameter;
+
+        // Origins for calling these extrinsics. For now these are expected to be root
+        type CreateProcessOrigin: EnsureOrigin<Self::Origin>;
+        type DisableProcessOrigin: EnsureOrigin<Self::Origin>;
+
+        type RoleKey: Parameter + Default + Ord;
+        type TokenMetadataKey: Parameter + Default + Ord;
+        type TokenMetadataValue: Parameter + Default;
+
+        // Origin for overriding weight calculation implementation
+        type WeightInfo: WeightInfo;
+    }
+
+    #[pallet::pallet]
+    #[pallet::generate_store(pub(super) trait Store)]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {}
+
+    /// Storage map definition
+    #[pallet::storage]
+    #[pallet::getter(fn processes_by_id_and_version)]
+    pub(super) type ProcessesByIdAndVersion<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        T::ProcessIdentifier,
+        Blake2_128Concat,
+        u32,
+        Process,
+        ValueQuery
+    >;
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        // TODO implement correct events for extrinsics
+        ProcessCreated,
+        ProcessDisabled
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        // TODO implement errors for extrinsics
+    }
+
+    // The pallet's dispatchable functions.
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        // TODO implement create_process with correct parameters and impl
+        #[pallet::weight(T::WeightInfo::create_process())]
+        pub(super) fn create_process(
+            origin: OriginFor<T>
+        ) -> DispatchResultWithPostInfo {
+            // Check it was signed and get the signer
+            T::CreateProcessOrigin::ensure_origin(origin)?;
+
+            Self::deposit_event(Event::ProcessCreated);
+            Ok(().into())
+        }
+
+        // TODO implement disable_process with correct parameters and impl
+        #[pallet::weight(T::WeightInfo::disable_process())]
+        pub(super) fn disable_process(
+            origin: OriginFor<T>
+        ) -> DispatchResultWithPostInfo {
+            T::DisableProcessOrigin::ensure_origin(origin)?;
+            Self::deposit_event(Event::ProcessDisabled);
+            Ok(().into())
+        }
+    }
+}
+
+impl<T: Config> ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue> for Pallet<T> {
+    type ProcessIdentifier = T::ProcessIdentifier;
+
+    // TODO: add arguments for validate process and implement so it can be used by pallet-simple-nft
+    fn validate_process(
+        _id: T::ProcessIdentifier,
+        _version: u32,
+        _sender: T::AccountId,
+        _inputs: &Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+        _outputs: &Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>) -> bool {
+        true
+    }
+}

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -91,20 +91,20 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
-        // TODO implement correct events for extrinsics
+        // TODO: implement correct events for extrinsics including params
         ProcessCreated,
         ProcessDisabled
     }
 
     #[pallet::error]
     pub enum Error<T> {
-        // TODO implement errors for extrinsics
+        // TODO: implement errors for extrinsics
     }
 
     // The pallet's dispatchable functions.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        // TODO implement create_process with correct parameters and impl
+        // TODO: implement create_process with correct parameters and impl
         #[pallet::weight(T::WeightInfo::create_process())]
         pub(super) fn create_process(
             origin: OriginFor<T>
@@ -116,7 +116,7 @@ pub mod pallet {
             Ok(().into())
         }
 
-        // TODO implement disable_process with correct parameters and impl
+        // TODO: implement disable_process with correct parameters and impl
         #[pallet::weight(T::WeightInfo::disable_process())]
         pub(super) fn disable_process(
             origin: OriginFor<T>
@@ -131,7 +131,7 @@ pub mod pallet {
 impl<T: Config> ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue> for Pallet<T> {
     type ProcessIdentifier = T::ProcessIdentifier;
 
-    // TODO: add arguments for validate process and implement so it can be used by pallet-simple-nft
+    // TODO: implement lookup of process and checking of restrictions
     fn validate_process(
         _id: T::ProcessIdentifier,
         _version: u32,

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -1,10 +1,13 @@
+// This file contains the different types of restrictions that can be evaluated during
+// a call to `validate_process`
+
 use codec::{Decode, Encode};
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
 pub enum Restriction {
   None
-  // TODO implement some actual restrictions
+  // TODO: implement some actual restrictions
 }
 
 impl Default for Restriction {
@@ -13,6 +16,7 @@ impl Default for Restriction {
   }
 }
 
+// TODO: update args appropriately and implement restriction functionality
 #[allow(dead_code)]
 pub fn validate_restriction(restriction: &Restriction) -> bool {
   match *restriction {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -1,0 +1,23 @@
+use codec::{Decode, Encode};
+
+#[derive(Encode, Decode, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub enum Restriction {
+  None
+  // TODO implement some actual restrictions
+}
+
+impl Default for Restriction {
+  fn default() -> Self {
+      Restriction::None
+  }
+}
+
+#[allow(dead_code)]
+pub fn validate_restriction(restriction: &Restriction) -> bool {
+  match *restriction {
+    Restriction::None => true
+    // TODO implement some actual restrictions
+  }
+}
+

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -63,6 +63,7 @@ impl system::Config for Test {
 impl pallet_process_validation::Config for Test {
     type Event = Event;
     type ProcessIdentifier = [u8;32];
+    type ProcessVersion = u32;
     type CreateProcessOrigin = system::EnsureRoot<u64>;
     type DisableProcessOrigin = system::EnsureRoot<u64>;
     type WeightInfo = ();

--- a/pallets/process-validation/src/tests.rs
+++ b/pallets/process-validation/src/tests.rs
@@ -1,7 +1,6 @@
 // Creating mock runtime here
 
-use crate as pallet_simple_nft;
-use codec::{Decode, Encode};
+use crate as pallet_process_validation;
 use frame_support::parameter_types;
 use frame_system as system;
 use sp_core::H256;
@@ -10,11 +9,11 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentityLookup},
 };
 
+mod create_process;
+mod disable_process;
+
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 type Block = frame_system::mocking::MockBlock<Test>;
-
-/// A hash of some data used by the chain.
-pub type Hash = sp_core::H256;
 
 // For testing the pallet, we construct most of a mock runtime. This means
 // first constructing a configuration type (`Test`) which `impl`s each of the
@@ -28,7 +27,7 @@ frame_support::construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic,
     {
         System: frame_system::{Module, Call, Config, Storage, Event<T>},
-        SimpleNFTModule: pallet_simple_nft::{Module, Call, Storage, Event<T>},
+        ProcessValidation: pallet_process_validation::{Module, Call, Storage, Event<T>},
     }
 );
 parameter_types! {
@@ -61,48 +60,16 @@ impl system::Config for Test {
     type SS58Prefix = SS58Prefix;
 }
 
-parameter_types! {
-    pub const MaxMetadataCount: u32 = 4;
-}
-
-#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq, Ord, PartialOrd)]
-pub enum Role {
-    Owner,
-    NotOwner,
-}
-
-impl Default for Role {
-    fn default() -> Self {
-        Role::Owner
-    }
-}
-
-#[derive(Encode, Decode, Clone, PartialEq, Debug, Eq)]
-pub enum MetadataValue<TokenId> {
-    File(Hash),
-    Literal([u8; 1]),
-    TokenId(TokenId),
-    None,
-}
-
-impl<T> Default for MetadataValue<T> {
-    fn default() -> Self {
-        MetadataValue::None
-    }
-}
-
-impl pallet_simple_nft::Config for Test {
+impl pallet_process_validation::Config for Test {
     type Event = Event;
-
-    type TokenId = u64;
-    type RoleKey = Role;
-    type TokenMetadataKey = u64;
-    type TokenMetadataValue = MetadataValue<Self::TokenId>;
-
-    type ProcessValidator = ();
+    type ProcessIdentifier = [u8;32];
+    type CreateProcessOrigin = system::EnsureRoot<u64>;
+    type DisableProcessOrigin = system::EnsureRoot<u64>;
     type WeightInfo = ();
 
-    type MaxMetadataCount = MaxMetadataCount;
+    type RoleKey = u32;
+    type TokenMetadataKey = u32;
+    type TokenMetadataValue = u128;
 }
 
 // This function basically just builds a genesis storage key/value store according to

--- a/pallets/process-validation/src/tests/create_process.rs
+++ b/pallets/process-validation/src/tests/create_process.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+use frame_support::{assert_ok};
+
+#[test]
+fn create_process_simple() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(ProcessValidation::create_process(Origin::root()));
+    });
+}

--- a/pallets/process-validation/src/tests/disable_process.rs
+++ b/pallets/process-validation/src/tests/disable_process.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+use frame_support::{assert_ok};
+
+#[test]
+fn create_process_simple() {
+    new_test_ext().execute_with(|| {
+        assert_ok!(ProcessValidation::disable_process(Origin::root()));
+    });
+}

--- a/pallets/process-validation/src/weights.rs
+++ b/pallets/process-validation/src/weights.rs
@@ -1,0 +1,30 @@
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{traits::Get, weights::Weight};
+use sp_std::marker::PhantomData;
+
+pub trait WeightInfo {
+    fn create_process() -> Weight;
+    fn disable_process() -> Weight;
+}
+
+/// TODO implement weights after benchmarking
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn create_process() -> Weight {
+        (0 as Weight)
+    }
+    fn disable_process() -> Weight {
+        (0 as Weight)
+    }
+}
+
+impl WeightInfo for () {
+    fn create_process() -> Weight {
+        (0 as Weight)
+    }
+    fn disable_process() -> Weight {
+        (0 as Weight)
+    }
+}

--- a/pallets/simple-nft/Cargo.toml
+++ b/pallets/simple-nft/Cargo.toml
@@ -45,5 +45,6 @@ std = [
     'frame-system/std',
     'frame-benchmarking/std',
     'sp-std/std',
+    'vitalam-pallet-traits/std'
 ]
 runtime-benchmarks = ['frame-benchmarking']

--- a/pallets/simple-nft/Cargo.toml
+++ b/pallets/simple-nft/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-simple-nft'
-version = "2.1.0"
+version = "2.1.1"
 
 
 [package.metadata.docs.rs]

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -6,6 +6,7 @@ pub use pallet::*;
 use sp_runtime::traits::{AtLeast32Bit, One};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
+use vitalam_pallet_traits::{ProcessIO, ProcessValidator};
 
 /// A FRAME pallet for handling non-fungible tokens
 use sp_std::prelude::*;
@@ -52,6 +53,7 @@ pub mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
 
+
     /// The pallet's configuration trait.
     #[pallet::config]
     pub trait Config: frame_system::Config {
@@ -65,6 +67,8 @@ pub mod pallet {
         type TokenMetadataValue: Parameter + Default;
 
         type WeightInfo: WeightInfo;
+
+        type ProcessValidator: ProcessValidator<Self::AccountId, Self::RoleKey, Self::TokenMetadataKey, Self::TokenMetadataValue>;
 
         // Maximum number of metadata items allowed per token
         #[pallet::constant]
@@ -123,13 +127,15 @@ pub mod pallet {
     // The pallet's dispatchable functions.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
-        // The value of the weight is an arbitrary value, for now
-        // #[weight = 10_000]
         #[pallet::weight(T::WeightInfo::run_process(inputs.len(), outputs.len()))]
         pub(super) fn run_process(
             origin: OriginFor<T>,
+            process: Option<(
+                <<T as pallet::Config>::ProcessValidator as ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>::ProcessIdentifier,
+                u32
+            )>,
             inputs: Vec<T::TokenId>,
-            outputs: Vec<Output<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+            outputs: Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
         ) -> DispatchResultWithPostInfo {
             // Check it was signed and get the signer
             let sender = ensure_signed(origin)?;
@@ -138,9 +144,14 @@ pub mod pallet {
             // Helper closures function
             let _next_token = |id: T::TokenId| -> T::TokenId { id + One::one() };
 
-            // TODO: add extra checks that origin is allowed to create tokens generically
-
-            // INPUT VALIDATION
+            // TODO: make this error appropriately
+            // TODO pass inputs properly
+            let _process_valid = match process {
+                Some(p) => {
+                    T::ProcessValidator::validate_process(p.0, p.1, sender.clone(), &vec![], &outputs)
+                },
+                None => true
+            };
 
             // check multiple tokens are not trying to have the same parent
             let mut parent_indices = BTreeSet::new();

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -6,7 +6,7 @@ pub use pallet::*;
 use sp_runtime::traits::{AtLeast32Bit, One};
 use sp_std::collections::btree_map::BTreeMap;
 use sp_std::collections::btree_set::BTreeSet;
-use vitalam_pallet_traits::{ProcessIO, ProcessValidator};
+use vitalam_pallet_traits::{ProcessValidator};
 
 /// A FRAME pallet for handling non-fungible tokens
 use sp_std::prelude::*;
@@ -130,12 +130,8 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::run_process(inputs.len(), outputs.len()))]
         pub(super) fn run_process(
             origin: OriginFor<T>,
-            process: Option<(
-                <<T as pallet::Config>::ProcessValidator as ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>::ProcessIdentifier,
-                u32
-            )>,
             inputs: Vec<T::TokenId>,
-            outputs: Vec<ProcessIO<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
+            outputs: Vec<Output<T::AccountId, T::RoleKey, T::TokenMetadataKey, T::TokenMetadataValue>>,
         ) -> DispatchResultWithPostInfo {
             // Check it was signed and get the signer
             let sender = ensure_signed(origin)?;
@@ -143,15 +139,6 @@ pub mod pallet {
             let now = <frame_system::Module<T>>::block_number();
             // Helper closures function
             let _next_token = |id: T::TokenId| -> T::TokenId { id + One::one() };
-
-            // TODO: make this error appropriately
-            // TODO pass inputs properly
-            let _process_valid = match process {
-                Some(p) => {
-                    T::ProcessValidator::validate_process(p.0, p.1, sender.clone(), &vec![], &outputs)
-                },
-                None => true
-            };
 
             // check multiple tokens are not trying to have the same parent
             let mut parent_indices = BTreeSet::new();

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -1,6 +1,6 @@
 // Tests to be written here
 
-use crate::{mock::*, Error, ProcessIO, Token};
+use crate::{mock::*, Error, Output, Token};
 use frame_support::{assert_err, assert_ok};
 use sp_core::H256;
 use sp_std::collections::btree_map::BTreeMap;
@@ -15,9 +15,8 @@ fn it_works_for_creating_token_with_file() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -52,9 +51,8 @@ fn it_works_for_creating_token_with_literal() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -89,9 +87,8 @@ fn it_works_for_creating_token_with_token_id_in_metadata() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::TokenId(0))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -126,9 +123,8 @@ fn it_works_for_creating_token_with_no_metadata_value() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -168,9 +164,8 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
         ]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -205,9 +200,8 @@ fn it_works_for_creating_token_with_multiple_roles() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -244,20 +238,19 @@ fn it_works_for_creating_many_token() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
             vec![
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None
@@ -325,20 +318,19 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
         let metadata2 = BTreeMap::from_iter(vec![(1, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
             vec![
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None
@@ -403,9 +395,8 @@ fn it_works_for_destroying_single_token() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -413,7 +404,7 @@ fn it_works_for_destroying_single_token() {
         )
         .unwrap();
         // create a token with no parents
-        assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()));
+        assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()));
         // assert no more tokens were created
         assert_eq!(SimpleNFTModule::last_token(), 1);
         // get the old token
@@ -444,20 +435,19 @@ fn it_works_for_destroying_many_tokens() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
             vec![
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None,
@@ -468,7 +458,6 @@ fn it_works_for_destroying_many_tokens() {
         // create a token with no parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             vec![1, 2, 3],
             Vec::new()
         ));
@@ -532,9 +521,8 @@ fn it_works_for_creating_and_destroy_single_tokens() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles0.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -544,9 +532,8 @@ fn it_works_for_creating_and_destroy_single_tokens() {
         // create a token with a parent
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             vec![1],
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles1.clone(),
                 metadata: metadata1.clone(),
                 parent_index: Some(0)
@@ -599,15 +586,14 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         let metadata3 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
             vec![
-                ProcessIO {
+                Output {
                     roles: roles0.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                ProcessIO {
+                Output {
                     roles: roles0.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
@@ -618,15 +604,14 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         // create 2 tokens with 2 parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             vec![1, 2],
             vec![
-                ProcessIO {
+                Output {
                     roles: roles0.clone(),
                     metadata: metadata2.clone(),
                     parent_index: Some(0)
                 },
-                ProcessIO {
+                Output {
                     roles: roles1.clone(),
                     metadata: metadata3.clone(),
                     parent_index: Some(1)
@@ -707,9 +692,8 @@ fn it_fails_for_destroying_single_token_as_incorrect_role() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -720,7 +704,7 @@ fn it_fails_for_destroying_single_token_as_incorrect_role() {
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), vec![1], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -737,9 +721,8 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -750,7 +733,7 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), vec![1], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -768,9 +751,8 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(2),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -779,9 +761,8 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         .unwrap();
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata1.clone(),
                 parent_index: None,
@@ -793,7 +774,7 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         let token_2 = SimpleNFTModule::tokens_by_id(2);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1, 2], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), vec![1, 2], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -813,25 +794,23 @@ fn it_fails_for_destroying_single_burnt_token() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
             }],
         )
         .unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
-                None,
                 vec![1],
-                vec![ProcessIO {
+                vec![Output {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
@@ -855,15 +834,14 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
             vec![
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                ProcessIO {
+                Output {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
@@ -871,7 +849,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
             ],
         )
         .unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
         // get old token
         let token_1 = SimpleNFTModule::tokens_by_id(1);
         // get old token
@@ -880,9 +858,8 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
-                None,
                 vec![1, 2],
-                vec![ProcessIO {
+                vec![Output {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None,
@@ -906,9 +883,8 @@ fn it_fails_for_invalid_index_to_set_parent_from_inputs() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -921,9 +897,8 @@ fn it_fails_for_invalid_index_to_set_parent_from_inputs() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(2),
-                None,
                 vec![1],
-                vec![ProcessIO {
+                vec![Output {
                     roles: roles.clone(),
                     metadata: metadata.clone(),
                     parent_index: Some(10),
@@ -945,9 +920,8 @@ fn it_fails_for_setting_multiple_tokens_to_have_the_same_parent() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -960,15 +934,14 @@ fn it_fails_for_setting_multiple_tokens_to_have_the_same_parent() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(2),
-                None,
                 vec![1],
                 vec![
-                    ProcessIO {
+                    Output {
                         roles: roles.clone(),
                         metadata: metadata.clone(),
                         parent_index: Some(0),
                     },
-                    ProcessIO {
+                    Output {
                         roles: roles.clone(),
                         metadata: metadata.clone(),
                         parent_index: Some(0),
@@ -998,9 +971,8 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
         ]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -1013,9 +985,8 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
-                None,
                 Vec::new(),
-                vec![ProcessIO {
+                vec![Output {
                     roles: roles.clone(),
                     metadata: metadata_too_many.clone(),
                     parent_index: None,
@@ -1038,9 +1009,8 @@ fn it_fails_for_creating_single_token_with_no_default_role() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
-            None,
             Vec::new(),
-            vec![ProcessIO {
+            vec![Output {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -1053,9 +1023,8 @@ fn it_fails_for_creating_single_token_with_no_default_role() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
-                None,
                 Vec::new(),
-                vec![ProcessIO {
+                vec![Output {
                     roles: roles_empty.clone(),
                     metadata: metadata.clone(),
                     parent_index: None,

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -1,6 +1,6 @@
 // Tests to be written here
 
-use crate::{mock::*, Error, Output, Token};
+use crate::{mock::*, Error, ProcessIO, Token};
 use frame_support::{assert_err, assert_ok};
 use sp_core::H256;
 use sp_std::collections::btree_map::BTreeMap;
@@ -15,8 +15,9 @@ fn it_works_for_creating_token_with_file() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -51,8 +52,9 @@ fn it_works_for_creating_token_with_literal() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -87,8 +89,9 @@ fn it_works_for_creating_token_with_token_id_in_metadata() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::TokenId(0))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -123,8 +126,9 @@ fn it_works_for_creating_token_with_no_metadata_value() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -164,8 +168,9 @@ fn it_works_for_creating_token_with_multiple_metadata_items() {
         ]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -200,8 +205,9 @@ fn it_works_for_creating_token_with_multiple_roles() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None
@@ -238,19 +244,20 @@ fn it_works_for_creating_many_token() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::File(H256::zero()))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
             vec![
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None
@@ -318,19 +325,20 @@ fn it_works_for_creating_many_token_with_varied_metadata() {
         let metadata2 = BTreeMap::from_iter(vec![(1, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
             vec![
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None
@@ -395,8 +403,9 @@ fn it_works_for_destroying_single_token() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -404,7 +413,7 @@ fn it_works_for_destroying_single_token() {
         )
         .unwrap();
         // create a token with no parents
-        assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()));
+        assert_ok!(SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()));
         // assert no more tokens were created
         assert_eq!(SimpleNFTModule::last_token(), 1);
         // get the old token
@@ -435,19 +444,20 @@ fn it_works_for_destroying_many_tokens() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
             vec![
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None,
@@ -458,6 +468,7 @@ fn it_works_for_destroying_many_tokens() {
         // create a token with no parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             vec![1, 2, 3],
             Vec::new()
         ));
@@ -521,8 +532,9 @@ fn it_works_for_creating_and_destroy_single_tokens() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles0.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -532,8 +544,9 @@ fn it_works_for_creating_and_destroy_single_tokens() {
         // create a token with a parent
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             vec![1],
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles1.clone(),
                 metadata: metadata1.clone(),
                 parent_index: Some(0)
@@ -586,14 +599,15 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         let metadata3 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
             vec![
-                Output {
+                ProcessIO {
                     roles: roles0.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                Output {
+                ProcessIO {
                     roles: roles0.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
@@ -604,14 +618,15 @@ fn it_works_for_creating_and_destroy_many_tokens() {
         // create 2 tokens with 2 parents
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             vec![1, 2],
             vec![
-                Output {
+                ProcessIO {
                     roles: roles0.clone(),
                     metadata: metadata2.clone(),
                     parent_index: Some(0)
                 },
-                Output {
+                ProcessIO {
                     roles: roles1.clone(),
                     metadata: metadata3.clone(),
                     parent_index: Some(1)
@@ -692,8 +707,9 @@ fn it_fails_for_destroying_single_token_as_incorrect_role() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -704,7 +720,7 @@ fn it_fails_for_destroying_single_token_as_incorrect_role() {
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), vec![1], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -721,8 +737,9 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -733,7 +750,7 @@ fn it_fails_for_destroying_single_token_as_other_signer() {
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), vec![1], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -751,8 +768,9 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(2),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -761,8 +779,9 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         .unwrap();
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata1.clone(),
                 parent_index: None,
@@ -774,7 +793,7 @@ fn it_fails_for_destroying_multiple_tokens_as_other_signer() {
         let token_2 = SimpleNFTModule::tokens_by_id(2);
         // Try to destroy token as incorrect user
         assert_err!(
-            SimpleNFTModule::run_process(Origin::signed(2), vec![1, 2], Vec::new()),
+            SimpleNFTModule::run_process(Origin::signed(2), None, vec![1, 2], Vec::new()),
             Error::<Test>::NotOwned
         );
         // assert no more tokens were created
@@ -794,23 +813,25 @@ fn it_fails_for_destroying_single_burnt_token() {
         let metadata1 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
             }],
         )
         .unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()).unwrap();
         // get old token
         let token = SimpleNFTModule::tokens_by_id(1);
         // Try to destroy token as incorrect user
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
+                None,
                 vec![1],
-                vec![Output {
+                vec![ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None
@@ -834,14 +855,15 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         let metadata2 = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
             vec![
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata0.clone(),
                     parent_index: None,
                 },
-                Output {
+                ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata1.clone(),
                     parent_index: None,
@@ -849,7 +871,7 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
             ],
         )
         .unwrap();
-        SimpleNFTModule::run_process(Origin::signed(1), vec![1], Vec::new()).unwrap();
+        SimpleNFTModule::run_process(Origin::signed(1), None, vec![1], Vec::new()).unwrap();
         // get old token
         let token_1 = SimpleNFTModule::tokens_by_id(1);
         // get old token
@@ -858,8 +880,9 @@ fn it_fails_for_destroying_multiple_tokens_with_burnt_token() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
+                None,
                 vec![1, 2],
-                vec![Output {
+                vec![ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata2.clone(),
                     parent_index: None,
@@ -883,8 +906,9 @@ fn it_fails_for_invalid_index_to_set_parent_from_inputs() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -897,8 +921,9 @@ fn it_fails_for_invalid_index_to_set_parent_from_inputs() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(2),
+                None,
                 vec![1],
-                vec![Output {
+                vec![ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata.clone(),
                     parent_index: Some(10),
@@ -920,8 +945,9 @@ fn it_fails_for_setting_multiple_tokens_to_have_the_same_parent() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -934,14 +960,15 @@ fn it_fails_for_setting_multiple_tokens_to_have_the_same_parent() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(2),
+                None,
                 vec![1],
                 vec![
-                    Output {
+                    ProcessIO {
                         roles: roles.clone(),
                         metadata: metadata.clone(),
                         parent_index: Some(0),
                     },
-                    Output {
+                    ProcessIO {
                         roles: roles.clone(),
                         metadata: metadata.clone(),
                         parent_index: Some(0),
@@ -971,8 +998,9 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
         ]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata0.clone(),
                 parent_index: None,
@@ -985,8 +1013,9 @@ fn it_fails_for_creating_single_token_with_too_many_metadata_items() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
+                None,
                 Vec::new(),
-                vec![Output {
+                vec![ProcessIO {
                     roles: roles.clone(),
                     metadata: metadata_too_many.clone(),
                     parent_index: None,
@@ -1009,8 +1038,9 @@ fn it_fails_for_creating_single_token_with_no_default_role() {
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
         SimpleNFTModule::run_process(
             Origin::signed(1),
+            None,
             Vec::new(),
-            vec![Output {
+            vec![ProcessIO {
                 roles: roles.clone(),
                 metadata: metadata.clone(),
                 parent_index: None,
@@ -1023,8 +1053,9 @@ fn it_fails_for_creating_single_token_with_no_default_role() {
         assert_err!(
             SimpleNFTModule::run_process(
                 Origin::signed(1),
+                None,
                 Vec::new(),
-                vec![Output {
+                vec![ProcessIO {
                     roles: roles_empty.clone(),
                     metadata: metadata.clone(),
                     parent_index: None,

--- a/pallets/traits/Cargo.toml
+++ b/pallets/traits/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "vitalam-pallet-traits"
+version = "1.0.0"
+edition = "2018"
+authors = ['Digital Catapult <https://www.digicatapult.org.uk>']
+license = 'Apache-2.0'
+repository = 'https://github.com/digicatapult/vitalam-node/'
+description = "Common pallet traits for the vitalam-node"
+
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '2.0.0'
+
+[dependencies]
+sp-std = { version = '3.0', default-features = false }
+frame-support = { default-features = false, version = '3.0.0' }
+
+[features]
+default = ['std']
+std = [
+	'sp-std/std',
+]

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -1,0 +1,30 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::Parameter;
+use codec::{Decode, Encode};
+
+use sp_std::prelude::*;
+use sp_std::collections::btree_map::BTreeMap;
+
+
+#[derive(Encode, Decode, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "std", derive(Debug))]
+pub struct ProcessIO<AccountId, RoleKey, TokenMetadataKey, TokenMetadataValue> {
+    pub roles: BTreeMap<RoleKey, AccountId>,
+    pub metadata: BTreeMap<TokenMetadataKey, TokenMetadataValue>,
+    pub parent_index: Option<u32>,
+}
+
+pub trait ProcessValidator<A, R, T, V> {
+  type ProcessIdentifier: Parameter;
+
+  fn validate_process(id: Self::ProcessIdentifier, version: u32, sender: A, inputs: &Vec<ProcessIO<A, R, T, V>>, outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool;
+}
+
+impl<A, R, T, V> ProcessValidator<A, R, T, V> for () {
+  type ProcessIdentifier = ();
+
+  fn validate_process(_id: Self::ProcessIdentifier, _version: u32, _sender: A, _inputs: &Vec<ProcessIO<A, R, T, V>>, _outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool {
+      true
+  }
+}

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -3,6 +3,7 @@
 use frame_support::Parameter;
 use codec::{Decode, Encode};
 
+use frame_support::sp_runtime::traits::AtLeast32Bit;
 use sp_std::prelude::*;
 use sp_std::collections::btree_map::BTreeMap;
 
@@ -17,14 +18,16 @@ pub struct ProcessIO<AccountId, RoleKey, TokenMetadataKey, TokenMetadataValue> {
 
 pub trait ProcessValidator<A, R, T, V> {
   type ProcessIdentifier: Parameter;
+  type ProcessVersion: Parameter + AtLeast32Bit;
 
-  fn validate_process(id: Self::ProcessIdentifier, version: u32, sender: A, inputs: &Vec<ProcessIO<A, R, T, V>>, outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool;
+  fn validate_process(id: Self::ProcessIdentifier, version: Self::ProcessVersion, sender: A, inputs: &Vec<ProcessIO<A, R, T, V>>, outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool;
 }
 
 impl<A, R, T, V> ProcessValidator<A, R, T, V> for () {
   type ProcessIdentifier = ();
+  type ProcessVersion = u32;
 
-  fn validate_process(_id: Self::ProcessIdentifier, _version: u32, _sender: A, _inputs: &Vec<ProcessIO<A, R, T, V>>, _outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool {
+  fn validate_process(_id: Self::ProcessIdentifier, _version: Self::ProcessVersion, _sender: A, _inputs: &Vec<ProcessIO<A, R, T, V>>, _outputs: &Vec<ProcessIO<A, R, T, V>>) -> bool {
       true
   }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = { optional = true, version = '0.3.1' }
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
-pallet-simple-nft = { version = '2.1.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
+pallet-simple-nft = { version = '2.1.1', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 pallet-process-validation = { version = '1.0.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,6 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '2.1.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
+pallet-process-validation = { version = '1.0.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -329,8 +329,20 @@ impl pallet_simple_nft::Config for Runtime {
     type RoleKey = Role;
     type TokenMetadataKey = [u8; 32];
     type TokenMetadataValue = MetadataValue<Self::TokenId>;
+    type ProcessValidator = ProcessValidation;
     type WeightInfo = pallet_simple_nft::weights::SubstrateWeight<Runtime>;
     type MaxMetadataCount = MaxMetadataCount;
+}
+
+impl pallet_process_validation::Config for Runtime {
+    type Event = Event;
+    type ProcessIdentifier = [u8; 32];
+    type CreateProcessOrigin = EnsureRoot<AccountId>;
+    type DisableProcessOrigin = EnsureRoot<AccountId>;
+    type WeightInfo = pallet_process_validation::weights::SubstrateWeight<Runtime>;
+    type RoleKey = Role;
+    type TokenMetadataKey = [u8; 32];
+    type TokenMetadataValue = MetadataValue<u128>;
 }
 
 pub struct DummyChangeMembers;
@@ -388,6 +400,7 @@ construct_runtime!(
         TransactionPayment: pallet_transaction_payment::{Module, Storage},
         Sudo: pallet_sudo::{Module, Call, Config<T>, Storage, Event<T>},
         SimpleNFTModule: pallet_simple_nft::{Module, Call, Storage, Event<T>},
+        ProcessValidation: pallet_process_validation::{Module, Call, Storage, Event<T>},
         NodeAuthorization: pallet_node_authorization::{Module, Call, Storage, Event<T>, Config<T>},
         Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},
         IpfsKey: pallet_symmetric_key::{Module, Call, Storage, Event<T>},

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 210,
+    spec_version: 220,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,8 +34,6 @@ pub use frame_support::{
     },
     StorageValue,
 };
-pub use pallet_balances::Call as BalancesCall;
-pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::CurrencyAdapter;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -320,13 +320,19 @@ impl<T> Default for MetadataValue<T> {
     }
 }
 
+type TokenId = u128;
+type TokenMetadataKey = [u8; 32];
+type TokenMetadataValue = MetadataValue<TokenId>;
+type ProcessIdentifier = [u8; 32];
+type ProcessVersion = u32;
+
 /// Configure the template pallet in pallets/simple-nft.
 impl pallet_simple_nft::Config for Runtime {
     type Event = Event;
-    type TokenId = u128;
+    type TokenId = TokenId;
     type RoleKey = Role;
-    type TokenMetadataKey = [u8; 32];
-    type TokenMetadataValue = MetadataValue<Self::TokenId>;
+    type TokenMetadataKey = TokenMetadataKey;
+    type TokenMetadataValue = TokenMetadataValue;
     type ProcessValidator = ProcessValidation;
     type WeightInfo = pallet_simple_nft::weights::SubstrateWeight<Runtime>;
     type MaxMetadataCount = MaxMetadataCount;
@@ -334,13 +340,14 @@ impl pallet_simple_nft::Config for Runtime {
 
 impl pallet_process_validation::Config for Runtime {
     type Event = Event;
-    type ProcessIdentifier = [u8; 32];
+    type ProcessIdentifier = ProcessIdentifier;
+    type ProcessVersion = ProcessVersion;
     type CreateProcessOrigin = EnsureRoot<AccountId>;
     type DisableProcessOrigin = EnsureRoot<AccountId>;
     type WeightInfo = pallet_process_validation::weights::SubstrateWeight<Runtime>;
     type RoleKey = Role;
-    type TokenMetadataKey = [u8; 32];
-    type TokenMetadataValue = MetadataValue<u128>;
+    type TokenMetadataKey = TokenMetadataKey;
+    type TokenMetadataValue = TokenMetadataValue;
 }
 
 pub struct DummyChangeMembers;


### PR DESCRIPTION
This PR lays the foundations for the process validation storage and evaluation pallet. There's no real functionality yet but what I have done is:

* created a new pallet `pallet-process-validation` which will store and manage the creation/disabling of process restrictions
* loosely coupled the new pallet to `pallet-simple-nft` via a shared trait and a struct that can describe a process input or output `ProcessIO`
* boiler plate for tests, benchmarking, weights

~I don't believe that this change will change any of the types used by the API~ Types still need updating
