### PR TITLE
Bug/Use original_id of parent for new token original_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-simple-nft"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7956,7 +7956,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "bs58",
  "frame-benchmarking",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.8.0'
+version = '2.8.1'
 
 [[bin]]
 name = 'vitalam-node'

--- a/pallets/simple-nft/Cargo.toml
+++ b/pallets/simple-nft/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-simple-nft'
-version = "2.1.1"
+version = "2.1.2"
 
 
 [package.metadata.docs.rs]
@@ -45,6 +45,6 @@ std = [
     'frame-system/std',
     'frame-benchmarking/std',
     'sp-std/std',
-    'vitalam-pallet-traits/std'
+    'vitalam-pallet-traits/std',
 ]
 runtime-benchmarks = ['frame-benchmarking']

--- a/pallets/simple-nft/src/lib.rs
+++ b/pallets/simple-nft/src/lib.rs
@@ -184,7 +184,8 @@ pub mod pallet {
             let (last, children) = outputs.iter().fold((last, Vec::new()), |(last, children), output| {
                 let next = _next_token(last);
                 let original_id = if output.parent_index.is_some() {
-                    inputs.get(output.parent_index.unwrap() as usize).unwrap().clone()
+                    let parent_id = inputs.get(output.parent_index.unwrap() as usize).unwrap();
+                    <TokensById<T>>::get(parent_id).original_id.clone()
                 } else {
                     next
                 };

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -686,6 +686,91 @@ fn it_works_for_creating_and_destroy_many_tokens() {
 }
 
 #[test]
+fn it_works_for_maintaining_original_id_through_multiple_children() {
+    new_test_ext().execute_with(|| {
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::None)]);
+        // initial token
+        SimpleNFTModule::run_process(
+            Origin::signed(1),
+            Vec::new(),
+            vec![Output {
+                roles: roles.clone(),
+                metadata: metadata.clone(),
+                parent_index: None,
+            }],
+        )
+        .unwrap();
+        // token with previous token as parent
+        assert_ok!(SimpleNFTModule::run_process(
+            Origin::signed(1),
+            vec![1],
+            vec![Output {
+                roles: roles.clone(),
+                metadata: metadata.clone(),
+                parent_index: Some(0)
+            },]
+        ));
+        // token with previous token as parent again
+        assert_ok!(SimpleNFTModule::run_process(
+            Origin::signed(1),
+            vec![2],
+            vec![Output {
+                roles: roles.clone(),
+                metadata: metadata.clone(),
+                parent_index: Some(0)
+            },]
+        ));
+        // check all tokens have the same original_id
+        let token = SimpleNFTModule::tokens_by_id(1);
+        assert_eq!(
+            token,
+            Token {
+                id: 1,
+                original_id: 1,
+                roles: roles.clone(),
+                creator: 1,
+                created_at: 0,
+                destroyed_at: Some(0),
+                metadata: metadata.clone(),
+                parents: Vec::new(),
+                children: Some(vec![2])
+            }
+        );
+        let token = SimpleNFTModule::tokens_by_id(2);
+        assert_eq!(
+            token,
+            Token {
+                id: 2,
+                original_id: 1,
+                roles: roles.clone(),
+                creator: 1,
+                created_at: 0,
+                destroyed_at: Some(0),
+                metadata: metadata.clone(),
+                parents: vec![1],
+                children: Some(vec![3])
+            }
+        );
+        let token = SimpleNFTModule::tokens_by_id(3);
+        assert_eq!(
+            token,
+            Token {
+                id: 3,
+                original_id: 1,
+                roles: roles.clone(),
+                creator: 1,
+                created_at: 0,
+                destroyed_at: None,
+                metadata: metadata.clone(),
+                parents: vec![2],
+                children: None
+            }
+        );
+    });
+}
+
+#[test]
 fn it_fails_for_destroying_single_token_as_incorrect_role() {
     new_test_ext().execute_with(|| {
         let roles = BTreeMap::from_iter(vec![(Default::default(), 1), (Role::NotOwner, 2)]);

--- a/pallets/simple-nft/src/weights.rs
+++ b/pallets/simple-nft/src/weights.rs
@@ -28,11 +28,11 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     fn run_process(i: usize, o: usize) -> Weight {
-        (11_627_000 as Weight)
+        (0 as Weight)
             // Standard Error: 7_000
-            .saturating_add((12_210_000 as Weight).saturating_mul(i as Weight))
+            .saturating_add((14_228_000 as Weight).saturating_mul(i as Weight))
             // Standard Error: 7_000
-            .saturating_add((6_131_000 as Weight).saturating_mul(o as Weight))
+            .saturating_add((8_026_000 as Weight).saturating_mul(o as Weight))
             .saturating_add(T::DbWeight::get().reads(1 as Weight))
             .saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(i as Weight)))
             .saturating_add(T::DbWeight::get().writes(1 as Weight))

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,7 +25,7 @@ hex-literal = { optional = true, version = '0.3.1' }
 serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
-pallet-simple-nft = { version = '2.1.1', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
+pallet-simple-nft = { version = '2.1.2', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
 pallet-process-validation = { version = '1.0.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }


### PR DESCRIPTION
When multiple tokens are about the same thing e.g a PO, we want them all to have the same `original_id`. This PR changes the pallet to correctly assign `original_id` rather than the `id` of a parent to a new token's `original_id`.

e.g. assuming all these tokens are about the same thing, such as a `Quote`. This PR goes from this:
Token 1: `id: 1` `original_id: 1`
Token 2: `id: 2` `original_id: 1`
Token 3: `id: 3` `original_id: 2` // this is wrong

to this
Token 1: `id: 1` `original_id: 1`
Token 2: `id: 2` `original_id: 1`
Token 3: `id: 3` `original_id: 1` // this is correct
