### PR TITLE
Altered service names so they are shorter

### DIFF
--- a/helm/vitalam-node/Chart.yaml
+++ b/helm/vitalam-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy vitalam nodes
 type: application
-version: 0.23.5
+version: 0.23.6
 appVersion: "0.0.1"

--- a/helm/vitalam-node/templates/service.yaml
+++ b/helm/vitalam-node/templates/service.yaml
@@ -50,7 +50,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullname }}-{{ $i }}-relay-chain-p2p
+  name: {{ $fullname }}-{{ $i }}-rc-p2p
 spec:
   type: NodePort
   externalTrafficPolicy: Local
@@ -67,7 +67,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $fullname }}-{{ $i }}-para-chain-p2p
+  name: {{ $fullname }}-{{ $i }}-pc-p2p
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/helm/vitalam-node/templates/statefulset.yaml
+++ b/helm/vitalam-node/templates/statefulset.yaml
@@ -217,9 +217,9 @@ spec:
               echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
               echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-relay-chain-p2p, saved ${RELAY_CHAIN_P2P_PORT} to /data/relay_chain_p2p_port"
               {{- if .Values.node.collator.isParachain }}
-              PARA_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-para-chain-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
+              PARA_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-pc-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
               echo "${PARA_CHAIN_P2P_PORT}" > /data/para_chain_p2p_port
-              echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-para-chain-p2p, saved ${PARA_CHAIN_P2P_PORT} to /data/para_chain_p2p_port"
+              echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-pc-p2p, saved ${PARA_CHAIN_P2P_PORT} to /data/para_chain_p2p_port"
               {{- end }}
               {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
               EXTERNAL_IP=$(curl {{ .Values.node.perNodeServices.setPublicAddressToExternalIp.ipRetrievalServiceUrl }})


### PR DESCRIPTION
Changes long service names to something shorter

When using this chart as a subchart we prepend the `releasename` with the parent charts name.  As such we get serviceNames that are too long.
```Error: INSTALLATION FAILED: Service "vitalam-identity-service-zuvp6takjp-vitalamnode-0-relay-chain-p2p" is invalid: metadata.name: Invalid value: "vitalam-identity-service-zuvp6takjp-vitalamnode-0-relay-chain-p2p": must be no more than 63 characters```