### PR TITLE
Adds types LoadBalancer and ClusterIP to valid service types

### DIFF
--- a/helm/vitalam-node/Chart.yaml
+++ b/helm/vitalam-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy vitalam nodes
 type: application
-version: 0.23.8
+version: 0.24.0
 appVersion: "0.0.1"

--- a/helm/vitalam-node/templates/_helpers.tpl
+++ b/helm/vitalam-node/templates/_helpers.tpl
@@ -75,3 +75,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name | lower }}
 {{- end }}
 {{- end }}
+
+{{/*
+Template the logic for serviceType
+*/}}
+{{- define "vitalam-node.serviceType" -}}
+{{- if eq $.Values.node.perNodeServices.p2pServiceType "NodePort" }}
+type: NodePort
+externalTrafficPolicy: Local
+{{- else if eq $.Values.node.perNodeServices.p2pServiceType "LoadBalancer" }}
+type: LoadBalancer
+{{- else if eq $.Values.node.perNodeServices.p2pServiceType "ClusterIP" }}
+type: ClusterIP
+{{- else }}
+{{- fail "node.perNodeServices.p2pServiceType must one of type ClusterIP, LoadBalancer or NodePort" }}
+{{- end }}
+{{- end }}

--- a/helm/vitalam-node/templates/service.yaml
+++ b/helm/vitalam-node/templates/service.yaml
@@ -23,7 +23,7 @@ spec:
       name: websocket-rpc
 ---
 {{range $i := until (.Values.node.replicas | int) }}
-{{- if $.Values.node.perNodeServices.createClusterIPService }}
+{{- if $.Values.node.perNodeServices.createApiService }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,7 +33,6 @@ metadata:
     instance: {{ $fullname }}-{{ $i }}
 spec:
   type: ClusterIP
-  clusterIP: None
   selector:
     {{- $selectorLabels | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
@@ -46,14 +45,13 @@ spec:
       name: prometheus
 {{- end }}
 ---
-{{- if $.Values.node.perNodeServices.createP2pNodePortService }}
+{{- if $.Values.node.perNodeServices.createP2pService }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullname }}-{{ $i }}-rc-p2p
 spec:
-  type: NodePort
-  externalTrafficPolicy: Local
+  {{ include "vitalam-node.serviceType" $ | nindent 2 }}
   selector:
     {{- $selectorLabels | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
@@ -61,21 +59,25 @@ spec:
     - name: p2p
       port: 30333
       targetPort: 30333
+  {{- if and $.Values.node.collator.isParachain (or (eq $.Values.node.perNodeServices.p2pServiceType "LoadBalancer") (eq $.Values.node.perNodeServices.p2pServiceType "ClusterIP")) }}
+    - name: pc-p2p
+      port: 30334
+      targetPort: 30334
+  {{- end }}
 {{- end }}
 ---
-{{- if and $.Values.node.collator.isParachain $.Values.node.perNodeServices.createP2pNodePortService }}
+{{- if and $.Values.node.collator.isParachain $.Values.node.perNodeServices.createP2pService (eq $.Values.node.perNodeServices.p2pServiceType "NodePort") }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullname }}-{{ $i }}-pc-p2p
 spec:
-  type: NodePort
-  externalTrafficPolicy: Local
+  {{ include "vitalam-node.serviceType" $ | nindent 2 }}
   selector:
     {{- $selectorLabels | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
   ports:
-    - name: p2p
+    - name: pc-p2p
       port: 30334
       targetPort: 30334
 {{- end }}

--- a/helm/vitalam-node/templates/statefulset.yaml
+++ b/helm/vitalam-node/templates/statefulset.yaml
@@ -205,26 +205,44 @@ spec:
             - mountPath: /data
               name: chain-data
         {{- end }}
-        {{- if .Values.node.perNodeServices.createP2pNodePortService }}
-        - name: retrieve-node-port
+        {{- if .Values.node.perNodeServices.createP2pService }}
+        - name: setup-services
           image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
           command: [ "/bin/sh" ]
           args:
             - -c
             - |
               POD_INDEX="${HOSTNAME##*-}"
+              {{- if eq .Values.node.perNodeServices.p2pServiceType "NodePort" }}
               RELAY_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-rc-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
-              echo "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
+              echo -n "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
               echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-rc-p2p, saved ${RELAY_CHAIN_P2P_PORT} to /data/relay_chain_p2p_port"
-              {{- if .Values.node.collator.isParachain }}
-              PARA_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-pc-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
-              echo "${PARA_CHAIN_P2P_PORT}" > /data/para_chain_p2p_port
-              echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-pc-p2p, saved ${PARA_CHAIN_P2P_PORT} to /data/para_chain_p2p_port"
+              {{- else if or (eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer") (eq .Values.node.perNodeServices.p2pServiceType "ClusterIP") }}
+              RELAY_CHAIN_P2P_PORT=30333
+              echo -n "${RELAY_CHAIN_P2P_PORT}" > /data/relay_chain_p2p_port
+              echo "Kubernetes service {{ $fullname }}-${POD_INDEX}-rc-p2p is ${RELAY_CHAIN_P2P_PORT}"
               {{- end }}
-              {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
-              EXTERNAL_IP=$(curl {{ .Values.node.perNodeServices.setPublicAddressToExternalIp.ipRetrievalServiceUrl }})
-              echo "${EXTERNAL_IP}" > /data/node_external_ip
-              echo "Retrieved external IP from {{ .Values.node.perNodeServices.ipRetrievalServiceUrl }}, saved ${EXTERNAL_IP} to /data/node_external_ip"
+              {{- if and .Values.node.collator.isParachain (eq .Values.node.perNodeServices.p2pServiceType "Nodeport") }}
+              PARA_CHAIN_P2P_PORT="$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-pc-p2p -o jsonpath='{.spec.ports[*].nodePort}')"
+              echo -n "${PARA_CHAIN_P2P_PORT}" > /data/para_chain_p2p_port
+              echo "Retrieved Kubernetes service node port from {{ $fullname }}-${POD_INDEX}-pc-p2p, saved ${PARA_CHAIN_P2P_PORT} to /data/para_chain_p2p_port"
+              {{- else if and .Values.node.collator.isParachain (or (eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer") (eq .Values.node.perNodeServices.p2pServiceType "ClusterIP")) }}
+              PARA_CHAIN_P2P_PORT=30334
+              echo -n "${PARA_CHAIN_P2P_PORT}" > /data/para_chain_p2p_port
+              echo "Kubernetes service {{ $fullname }}-${POD_INDEX}-rc-p2p is ${PARA_CHAIN_P2P_PORT}"
+              {{- end }}
+              {{- if and .Values.node.perNodeServices.setPublicAddressToExternal.enabled (eq .Values.node.perNodeServices.p2pServiceType "NodePort") }}
+              EXTERNAL_ADDRESS=$(curl -sS {{ .Values.node.perNodeServices.setPublicAddressToExternal.ipRetrievalServiceUrl }})
+              echo -n "${EXTERNAL_ADDRESS}" > /data/node_external_address
+              echo "Retrieved external IP from {{ .Values.node.perNodeServices.setPublicAddressToExternal.ipRetrievalServiceUrl }}, saved $(cat /data/node_external_address) to /data/node_external_address"
+              {{- else if and .Values.node.perNodeServices.setPublicAddressToExternal.enabled (eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer") }}
+              EXTERNAL_ADDRESS=$(kubectl --namespace {{ .Release.Namespace }} get service {{ $fullname }}-${POD_INDEX}-rc-p2p -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+              echo -n "${EXTERNAL_ADDRESS}" > /data/node_external_address
+              echo "External hostname is ${EXTERNAL_ADDRESS}, saved to /data/node_external_address"
+              {{- else if eq .Values.node.perNodeServices.p2pServiceType "ClusterIP" }}
+              EXTERNAL_ADDRESS={{ $fullname }}-${POD_INDEX}-rc-p2p.{{ .Release.Namespace }}.svc.cluster.local
+              echo -n "${EXTERNAL_ADDRESS}" > /data/node_external_address
+              echo "External hostname is ${EXTERNAL_ADDRESS}, saved to /data/node_external_address"
               {{- end }}
           volumeMounts:
             - mountPath: /data
@@ -238,11 +256,10 @@ spec:
           args:
             - -c
             - |
-              {{- if .Values.node.perNodeServices.createP2pNodePortService }}
-              {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
-              EXTERNAL_IP="$(cat /data/node_external_ip)"
-              echo "EXTERNAL_IP=${EXTERNAL_IP}"
-              {{- end }}
+              {{- if .Values.node.perNodeServices.createP2pService }}
+              if [ ! -s /data/node_external_address ]; then echo "EXTERNAL_ADDRESS is empty" && exit 1 ; fi
+              EXTERNAL_ADDRESS="$(cat /data/node_external_address)"
+              echo "EXTERNAL_ADDRESS=${EXTERNAL_ADDRESS}"
               RELAY_CHAIN_P2P_PORT="$(cat /data/relay_chain_p2p_port)"
               echo "RELAY_CHAIN_P2P_PORT=${RELAY_CHAIN_P2P_PORT}"
               {{- if .Values.node.collator.isParachain }}
@@ -264,9 +281,15 @@ spec:
                 --light \
                 {{- end }}
                 {{- if .Values.node.collator.isParachain }}
-                {{- if .Values.node.perNodeServices.createP2pNodePortService }}
-                {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
-                --public-addr=/ip4/${EXTERNAL_IP}/tcp/${PARA_CHAIN_P2P_PORT} \
+                {{- if .Values.node.perNodeServices.createP2pService }}
+                {{- if .Values.node.perNodeServices.setPublicAddressToExternal.enabled }}
+                {{- if eq .Values.node.perNodeServices.p2pServiceType "NodePort" }}
+                --public-addr=/ip4/${EXTERNAL_ADDRESS}/tcp/${PARA_CHAIN_P2P_PORT} \
+                {{- else if eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer" }}
+                --public-addr=/dns4/${EXTERNAL_ADDRESS}/tcp/${PARA_CHAIN_P2P_PORT} \
+                {{- end }}
+                {{- else if and (not .Values.node.perNodeServices.setPublicAddressToExternal.enabled) (eq .Values.node.perNodeServices.p2pServiceType "ClusterIP") }}
+                --public-addr=/dns4/${EXTERNAL_ADDRESS}/tcp/${PARA_CHAIN_P2P_PORT} \
                 {{- end }}
                 --listen-addr=/ip4/0.0.0.0/tcp/${PARA_CHAIN_P2P_PORT} \
                 {{- end }}
@@ -280,17 +303,23 @@ spec:
                 {{- if .Values.node.tracing.enabled }}
                 --jaeger-agent=127.0.0.1:{{ .Values.jaegerAgent.ports.compactPort }} \
                 {{- end }}
-                {{- join " " .Values.node.flags | nindent 16 }}
-                {{- if .Values.node.collator.isParachain }} \
+                {{- join " " .Values.node.flags | nindent 16 }} \
+                {{- if .Values.node.collator.isParachain }}
                 -- \
                 --base-path=/data/relay/ \
                 {{- end }}
                 {{- if .Values.node.collator.relayChainCustomChainspecUrl }}
                 --chain=/data/relay_chain_chainspec.json \
                 {{- end }}
-                {{- if .Values.node.perNodeServices.createP2pNodePortService }}
-                {{- if .Values.node.perNodeServices.setPublicAddressToExternalIp.enabled }}
-                --public-addr=/ip4/${EXTERNAL_IP}/tcp/${RELAY_CHAIN_P2P_PORT} \
+                {{- if .Values.node.perNodeServices.createP2pService }}
+                {{- if .Values.node.perNodeServices.setPublicAddressToExternal.enabled }}
+                {{- if eq .Values.node.perNodeServices.p2pServiceType "NodePort" }}
+                --public-addr=/ip4/${EXTERNAL_ADDRESS}/tcp/${RELAY_CHAIN_P2P_PORT} \
+                {{- else if eq .Values.node.perNodeServices.p2pServiceType "LoadBalancer" }}
+                --public-addr=/dns4/${EXTERNAL_ADDRESS}/tcp/${RELAY_CHAIN_P2P_PORT} \
+                {{- end }}
+                {{- else if and (not .Values.node.perNodeServices.setPublicAddressToExternal.enabled) (eq .Values.node.perNodeServices.p2pServiceType "ClusterIP") }}
+                --public-addr=/dns4/${EXTERNAL_ADDRESS}/tcp/${RELAY_CHAIN_P2P_PORT} \
                 {{- end }}
                 --listen-addr=/ip4/0.0.0.0/tcp/${RELAY_CHAIN_P2P_PORT} \
                 {{- end }}
@@ -319,6 +348,11 @@ spec:
             - containerPort: 30333
               name: p2p
               protocol: TCP
+          {{- if .Values.node.collator.isParachain }}
+            - containerPort: 30334
+              name: pc-p2p
+              protocol: TCP
+          {{- end }}
           {{- if .Values.node.enableStartupProbe }}
           # On startup, retry the connection to the /health endpoint every 10s for 5 min before killing the container
           startupProbe:

--- a/helm/vitalam-node/templates/statefulset.yaml
+++ b/helm/vitalam-node/templates/statefulset.yaml
@@ -206,7 +206,7 @@ spec:
               name: chain-data
         {{- end }}
         {{- if .Values.node.perNodeServices.createP2pService }}
-        - name: setup-services
+        - name: query-services
           image: {{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}
           command: [ "/bin/sh" ]
           args:

--- a/helm/vitalam-node/values.yaml
+++ b/helm/vitalam-node/values.yaml
@@ -76,7 +76,7 @@ node:
   #  relayChainPath: ""
   #  relayChainDataKubernetesVolumeSnapshot: ""
   #  relayChainDataGcsBucketUrl: ""
-  #  relayChainFlags: 
+  #  relayChainFlags:
   enableStartupProbe: true
   enableReadinessProbe: true
   flags:

--- a/helm/vitalam-node/values.yaml
+++ b/helm/vitalam-node/values.yaml
@@ -69,14 +69,14 @@ node:
   # chainDataGcsBucketUrl: ""
   collator:
     isParachain: false
-     # relayChain: polkadot
+  #  relayChain: polkadot
   #  relayChainCustomChainspecUrl: ""
   #  relayChainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
   #  relayChainDataSnapshotFormat: 7z
   #  relayChainPath: ""
   #  relayChainDataKubernetesVolumeSnapshot: ""
   #  relayChainDataGcsBucketUrl: ""
-  #  relayChainFlags:
+  #  relayChainFlags: "--prometheus-external"
   enableStartupProbe: true
   enableReadinessProbe: true
   flags:
@@ -103,10 +103,11 @@ node:
     # interval: 10s
     # scrapeTimeout: 10s
   perNodeServices:
-    createClusterIPService: true
-    createP2pNodePortService: true
-    setPublicAddressToExternalIp:
-      enabled: false
+    createApiService: true
+    createP2pService: true
+    p2pServiceType: ClusterIP #Must be type ClusterIP, NodePort or LoadBalancer, If using type LoadBalancer then you must set NodeSelecter accordingly.
+    setPublicAddressToExternal:
+      enabled: true
       ipRetrievalServiceUrl: https://ifconfig.io/ip
   # podManagementPolicy: Parallel
 

--- a/helm/vitalam-node/values.yaml
+++ b/helm/vitalam-node/values.yaml
@@ -69,14 +69,14 @@ node:
   # chainDataGcsBucketUrl: ""
   collator:
     isParachain: false
-  #  relayChain: polkadot
+     # relayChain: polkadot
   #  relayChainCustomChainspecUrl: ""
   #  relayChainDataSnapshotUrl: "https://dot-rocksdb.polkashots.io/snapshot"
   #  relayChainDataSnapshotFormat: 7z
   #  relayChainPath: ""
   #  relayChainDataKubernetesVolumeSnapshot: ""
   #  relayChainDataGcsBucketUrl: ""
-  #  relayChainFlags: "--prometheus-external"
+  #  relayChainFlags: 
   enableStartupProbe: true
   enableReadinessProbe: true
   flags:
@@ -105,7 +105,7 @@ node:
   perNodeServices:
     createApiService: true
     createP2pService: true
-    p2pServiceType: ClusterIP #Must be type ClusterIP, NodePort or LoadBalancer, If using type LoadBalancer then you must set NodeSelecter accordingly.
+    p2pServiceType: ClusterIP #Must be type ClusterIP, NodePort or LoadBalancer, If using type NodePort or LoadBalancer then you must set NodeSelecter accordingly.
     setPublicAddressToExternal:
       enabled: true
       ipRetrievalServiceUrl: https://ifconfig.io/ip

--- a/helm/vitalam-node/values.yaml
+++ b/helm/vitalam-node/values.yaml
@@ -105,7 +105,7 @@ node:
   perNodeServices:
     createApiService: true
     createP2pService: true
-    p2pServiceType: ClusterIP #Must be type ClusterIP, NodePort or LoadBalancer, If using type NodePort or LoadBalancer then you must set NodeSelecter accordingly.
+    p2pServiceType: ClusterIP  # Must be type ClusterIP, NodePort or LoadBalancer, If using type NodePort or LoadBalancer then you must set NodeSelecter accordingly.
     setPublicAddressToExternal:
       enabled: true
       ipRetrievalServiceUrl: https://ifconfig.io/ip


### PR DESCRIPTION
Adds ability to use different service types `ClusterIP` and `LoadBalancer`
Logic to determine if to use a public addr
Fixes some bugs in the parity chart with regards to bash flow logic on Parachain section
Parachain functionality needs to be tested against `Polkadot` container in the coming week.