### PR TITLE
bug/custom-node-key non-unique

### DIFF
--- a/helm/vitalam-node/Chart.yaml
+++ b/helm/vitalam-node/Chart.yaml
@@ -6,5 +6,5 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy vitalam nodes
 type: application
-version: 0.24.0
+version: 0.24.1
 appVersion: "0.0.1"

--- a/helm/vitalam-node/templates/customNodeKeySecret.yaml
+++ b/helm/vitalam-node/templates/customNodeKeySecret.yaml
@@ -1,9 +1,10 @@
+{{ $fullname :=  include "vitalam-node.fullname" . }}
 {{ if .Values.node.persistGeneratedNodeKey }}
 {{ else if .Values.node.customNodeKey }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: custom-node-key
+  name: {{ $fullname }}-custom-node-key
 data:
   custom-node-key: {{ .Values.node.customNodeKey | mustRegexFind "^[0-9a-zA-Z]{64}$" | b64enc }}
 {{ end }}

--- a/helm/vitalam-node/templates/statefulset.yaml
+++ b/helm/vitalam-node/templates/statefulset.yaml
@@ -461,7 +461,7 @@ spec:
       {{- else if .Values.node.customNodeKey }}
         - name: custom-node-key
           secret:
-            secretName: custom-node-key
+            secretName: {{ $fullname }}-custom-node-key
       {{- end }}
   volumeClaimTemplates:
     - apiVersion: v1


### PR DESCRIPTION
Fixed a bug whereby you couldn't use a custom node key on more than a singe helm release per namespace