### PR TITLE
IN-101 Restrict Metadata value to be a fixed value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7956,7 +7956,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.11.0"
+version = "2.12.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "vitalam-node-runtime"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "input_index": "u32",
     "metadata_key": "TokenMetadataKey",
     "metadata_value": "TokenMetadataValue"
-},
+  },
   "IsNew": "bool",
   "Restrictions": "Vec<Restriction>"
-},
+}
 ```
 
 ### SimpleNFT pallet

--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "None": "()",
       "SenderOwnsAllInputs": "()",
       "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
-      "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction"
+      "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
+      "FixedMetadataValue": "FixedMetadataValueRestriction"
     }
   },
   "FixedNumberOfInputsRestriction": {
@@ -170,9 +171,14 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
   "FixedNumberOfOutputsRestriction": {
     "num_outputs": "u32"
   },
+  "FixedMetadataValueRestriction": {
+    "input_index": "u32",
+    "metadata_key": "TokenMetadataKey",
+    "metadata_value": "TokenMetadataValue"
+},
   "IsNew": "bool",
   "Restrictions": "Vec<Restriction>"
-}
+},
 ```
 
 ### SimpleNFT pallet

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-vitalam-node-runtime = { path = '../runtime', version = '2.4.0' }
+vitalam-node-runtime = { path = '../runtime', version = '2.6.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.11.0'
+version = '2.12.0'
 
 [[bin]]
 name = 'vitalam-node'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-process-validation'
-version = "1.3.0"
+version = "1.4.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -17,7 +17,6 @@ mod benchmarking;
 // import the restrictions module where all our restriction types are defined
 mod restrictions;
 use restrictions::*;
-use Restriction::*;
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
@@ -36,16 +35,17 @@ impl Default for ProcessStatus {
 #[cfg_attr(feature = "std", derive(Debug))]
 pub struct Process<TokenMetadataKey, TokenMetadataValue>
 where
-TokenMetadataKey: Parameter + Default + Ord,
-TokenMetadataValue: Parameter + Default, {
+    TokenMetadataKey: Parameter + Default + Ord,
+    TokenMetadataValue: Parameter + Default,
+{
     status: ProcessStatus,
     restrictions: Vec<Restriction<TokenMetadataKey, TokenMetadataValue>>,
 }
 
-impl<TokenMetadataKey, TokenMetadataValue> Default for Process<TokenMetadataKey, TokenMetadataValue> 
+impl<TokenMetadataKey, TokenMetadataValue> Default for Process<TokenMetadataKey, TokenMetadataValue>
 where
     TokenMetadataKey: Parameter + Default + Ord,
-    TokenMetadataValue: Parameter + Default, 
+    TokenMetadataValue: Parameter + Default,
 {
     fn default() -> Self {
         Process {
@@ -121,7 +121,12 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         // id, version, restrictions, is_new
-        ProcessCreated(T::ProcessIdentifier, T::ProcessVersion, Vec<Restriction<T::TokenMetadataKey, T::TokenMetadataValue>>, bool),
+        ProcessCreated(
+            T::ProcessIdentifier,
+            T::ProcessVersion,
+            Vec<Restriction<T::TokenMetadataKey, T::TokenMetadataValue>>,
+            bool,
+        ),
         //id, version
         ProcessDisabled(T::ProcessIdentifier, T::ProcessVersion),
     }

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -275,7 +275,7 @@ impl<T: Config> ProcessValidator<T::AccountId, T::RoleKey, T::TokenMetadataKey, 
                         T::RoleKey,
                         T::TokenMetadataKey,
                         T::TokenMetadataValue,
-                    >(&restriction, &sender, &inputs, &outputs);
+                    >(restriction, &sender, &inputs, &outputs);
 
                     if !is_valid {
                         return false;

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -16,7 +16,8 @@ mod benchmarking;
 
 // import the restrictions module where all our restriction types are defined
 mod restrictions;
-use restrictions::{validate_restriction, Restriction};
+use restrictions::*;
+use Restriction::*;
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
@@ -33,12 +34,19 @@ impl Default for ProcessStatus {
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-pub struct Process {
+pub struct Process<TokenMetadataKey, TokenMetadataValue>
+where
+TokenMetadataKey: Parameter + Default + Ord,
+TokenMetadataValue: Parameter + Default, {
     status: ProcessStatus,
-    restrictions: Vec<Restriction>,
+    restrictions: Vec<Restriction<TokenMetadataKey, TokenMetadataValue>>,
 }
 
-impl Default for Process {
+impl<TokenMetadataKey, TokenMetadataValue> Default for Process<TokenMetadataKey, TokenMetadataValue> 
+where
+    TokenMetadataKey: Parameter + Default + Ord,
+    TokenMetadataValue: Parameter + Default, 
+{
     fn default() -> Self {
         Process {
             status: ProcessStatus::Disabled,
@@ -56,8 +64,6 @@ pub mod pallet {
     use super::*;
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
-
-    type Restrictions = Vec<Restriction>;
 
     /// The pallet's configuration trait.
     #[pallet::config]
@@ -96,7 +102,7 @@ pub mod pallet {
         T::ProcessIdentifier,
         Blake2_128Concat,
         T::ProcessVersion,
-        Process,
+        Process<T::TokenMetadataKey, T::TokenMetadataValue>,
         ValueQuery,
     >;
 
@@ -115,7 +121,7 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         // id, version, restrictions, is_new
-        ProcessCreated(T::ProcessIdentifier, T::ProcessVersion, Vec<Restriction>, bool),
+        ProcessCreated(T::ProcessIdentifier, T::ProcessVersion, Vec<Restriction<T::TokenMetadataKey, T::TokenMetadataValue>>, bool),
         //id, version
         ProcessDisabled(T::ProcessIdentifier, T::ProcessVersion),
     }
@@ -139,7 +145,7 @@ pub mod pallet {
         pub(super) fn create_process(
             origin: OriginFor<T>,
             id: T::ProcessIdentifier,
-            restrictions: Vec<Restriction>,
+            restrictions: Vec<Restriction<T::TokenMetadataKey, T::TokenMetadataValue>>,
         ) -> DispatchResultWithPostInfo {
             T::CreateProcessOrigin::ensure_origin(origin)?;
             let version: T::ProcessVersion = Pallet::<T>::update_version(id.clone()).unwrap();
@@ -192,7 +198,7 @@ pub mod pallet {
         pub fn persist_process(
             id: &T::ProcessIdentifier,
             v: &T::ProcessVersion,
-            r: &Restrictions,
+            r: &Vec<Restriction<T::TokenMetadataKey, T::TokenMetadataValue>>,
         ) -> Result<(), Error<T>> {
             return match <ProcessModel<T>>::contains_key(&id, &v) {
                 true => Err(Error::<T>::AlreadyExists),
@@ -211,7 +217,7 @@ pub mod pallet {
         }
 
         pub fn set_disabled(id: &T::ProcessIdentifier, version: &T::ProcessVersion) -> Result<(), Error<T>> {
-            let process: Process = <ProcessModel<T>>::get(&id, &version);
+            let process = <ProcessModel<T>>::get(&id, &version);
             return match process.status == ProcessStatus::Disabled {
                 true => Err(Error::<T>::AlreadyDisabled),
                 false => {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -39,7 +39,7 @@ where
 }
 
 pub fn validate_restriction<A, R, T, V>(
-    restriction: &Restriction<T, V>,
+    restriction: Restriction<T, V>,
     sender: &A,
     inputs: &Vec<ProcessIO<A, R, T, V>>,
     outputs: &Vec<ProcessIO<A, R, T, V>>,
@@ -50,16 +50,16 @@ where
     T: Parameter + Default + Ord,
     V: Parameter + Default,
 {
-    match &*restriction {
+    match restriction {
         Restriction::<T, V>::None => true,
-        Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == *num_inputs as usize,
-        Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == *num_outputs as usize,
+        Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == num_inputs as usize,
+        Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == num_outputs as usize,
         Restriction::FixedMetadataValue {
             input_index,
             metadata_key,
             metadata_value,
         } => {
-            let selected_input = &inputs[*input_index as usize];
+            let selected_input = &inputs[input_index as usize];
             let meta = selected_input.metadata.get(&metadata_key);
             meta == Some(&metadata_value)
         }
@@ -85,14 +85,14 @@ mod tests {
 
     #[test]
     fn no_restriction_succeeds() {
-        let result = validate_restriction::<u64, u32, u32, u64>(&Restriction::None, &1u64, &Vec::new(), &Vec::new());
+        let result = validate_restriction::<u64, u32, u32, u64>(Restriction::None, &1u64, &Vec::new(), &Vec::new());
         assert!(result);
     }
 
     #[test]
     fn sender_owns_inputs_restriction_no_inputs_succeeds() {
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::SenderOwnsAllInputs,
+            Restriction::SenderOwnsAllInputs,
             &1u64,
             &Vec::new(),
             &Vec::new(),
@@ -117,7 +117,7 @@ mod tests {
             },
         ];
         let result =
-            validate_restriction::<u64, u32, u32, u64>(&Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+            validate_restriction::<u64, u32, u32, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
         assert!(result);
     }
 
@@ -138,7 +138,7 @@ mod tests {
             },
         ];
         let result =
-            validate_restriction::<u64, u32, u32, u64>(&Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+            validate_restriction::<u64, u32, u32, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
         assert!(!result);
     }
 
@@ -161,7 +161,7 @@ mod tests {
             },
         ];
         let result =
-            validate_restriction::<u64, u32, u32, u64>(&Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+            validate_restriction::<u64, u32, u32, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
         assert!(!result);
     }
 
@@ -184,7 +184,7 @@ mod tests {
             },
         ];
         let result =
-            validate_restriction::<u64, u32, u32, u64>(&Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
+            validate_restriction::<u64, u32, u32, u64>(Restriction::SenderOwnsAllInputs, &1u64, &inputs, &Vec::new());
         assert!(!result);
     }
 
@@ -215,7 +215,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedNumberOfInputs { num_inputs: 4 },
+            Restriction::FixedNumberOfInputs { num_inputs: 4 },
             &1u64,
             &inputs,
             &Vec::new(),
@@ -240,7 +240,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedNumberOfInputs { num_inputs: 1 },
+            Restriction::FixedNumberOfInputs { num_inputs: 1 },
             &1u64,
             &inputs,
             &Vec::new(),
@@ -265,7 +265,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedNumberOfOutputs { num_outputs: 2 },
+            Restriction::FixedNumberOfOutputs { num_outputs: 2 },
             &1u64,
             &Vec::new(),
             &outputs,
@@ -290,7 +290,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedNumberOfOutputs { num_outputs: 1 },
+            Restriction::FixedNumberOfOutputs { num_outputs: 1 },
             &1u64,
             &Vec::new(),
             &outputs,
@@ -322,7 +322,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedMetadataValue {
+            Restriction::FixedMetadataValue {
                 input_index: 2,
                 metadata_key: 2,
                 metadata_value: 110,
@@ -358,7 +358,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedMetadataValue {
+            Restriction::FixedMetadataValue {
                 input_index: 1,
                 metadata_key: 2,
                 metadata_value: 110,
@@ -394,7 +394,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedMetadataValue {
+            Restriction::FixedMetadataValue {
                 input_index: 2,
                 metadata_key: 2,
                 metadata_value: 45,
@@ -432,7 +432,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedMetadataValue {
+            Restriction::FixedMetadataValue {
                 input_index: 2,
                 metadata_key: 3,
                 metadata_value: 110,
@@ -470,7 +470,7 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            &Restriction::FixedMetadataValue {
+            Restriction::FixedMetadataValue {
                 input_index: 1,
                 metadata_key: 2,
                 metadata_value: 110,

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -61,11 +61,7 @@ where
         } => {
             let selected_input = &inputs[*input_index as usize];
             let meta = selected_input.metadata.get(&metadata_key);
-            if meta != None {
-                return meta == Some(&metadata_value);
-            } else {
-                return false;
-            }
+            meta == Some(&metadata_value)
         }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -15,7 +15,7 @@ pub enum Restriction {
     SenderOwnsAllInputs,
     FixedNumberOfInputs { num_inputs: u32 },
     FixedNumberOfOutputs { num_outputs: u32 },
-    FixedMetadataValue { input_index: u32, metadata_key: GenericMeta(T), metadata_value: u32 }
+    FixedMetadataValue { input_index: u32, metadata_key: GenericMeta(u32), metadata_value: u32 }
 }
 
 impl Default for Restriction {
@@ -42,7 +42,9 @@ where
         Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == num_outputs as usize,
         Restriction::FixedMetadataValue { input_index, metadata_key, metadata_value} => {
             let selectedInput = &inputs[input_index as usize];
-            for input in inputs{
+            let meta = selectedInput.metadata.get(&metadata_key);
+            return meta == metadata_value;
+            /* for input in inputs{
                 let matchesFixedValue = match input.metadata.get(&metadata_key) {
                     Some(metaData) => metaData == &metadata_value as V,
                     None => false,
@@ -50,7 +52,7 @@ where
             }
             let contains = selectedInput.metadata.contains_key(metadata_key);
             let meta_value = selectedInput.metadata.get(metadata_key);
-            return false;
+            return false; */
         }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -8,7 +8,6 @@ use vitalam_pallet_traits::ProcessIO;
 
 #[derive(Encode, Decode, Clone, PartialEq)]
 #[cfg_attr(feature = "std", derive(Debug))]
-
 pub enum Restriction<TokenMetadataKey, TokenMetadataValue>
 where
     TokenMetadataKey: Parameter + Default + Ord,
@@ -29,14 +28,18 @@ where
     },
 }
 
-impl Default for Restriction {
+impl<TokenMetadataKey, TokenMetadataValue> Default for Restriction<TokenMetadataKey, TokenMetadataValue>
+where
+    TokenMetadataKey: Parameter + Default + Ord,
+    TokenMetadataValue: Parameter + Default,
+{
     fn default() -> Self {
         Restriction::None
     }
 }
 
 pub fn validate_restriction<A, R, T, V>(
-    restriction: &Restriction,
+    restriction: &Restriction<T, V>,
     sender: &A,
     inputs: &Vec<ProcessIO<A, R, T, V>>,
     outputs: &Vec<ProcessIO<A, R, T, V>>,
@@ -47,22 +50,23 @@ where
     T: Parameter + Default + Ord,
     V: Parameter + Default,
 {
-    match *restriction {
-        Restriction::None => true, // TODO implement some actual restrictions
-        Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == num_inputs as usize,
-        Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == num_outputs as usize,
+    match restriction {
+        Restriction::<T, V>::None => true, // TODO implement some actual restrictions
+        Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == *num_inputs as usize,
+        Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == *num_outputs as usize,
         Restriction::FixedMetadataValue {
             input_index,
             metadata_key,
             metadata_value,
         } => {
-            let selectedInput = &inputs[input_index];
+            /* let selectedInput = &inputs[input_index as usize];
             let meta = selectedInput.metadata.get(&metadata_key);
-            if( meta ){
+            if meta != None {
                 return meta == metadata_value;
-            } else { 
+            } else {
                 return false;
-            }
+            } */
+            true
         }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {
@@ -84,7 +88,7 @@ mod tests {
     use super::*;
     use sp_std::collections::btree_map::BTreeMap;
 
-    #[test]
+    /*#[test]
     fn no_restriction_succeeds() {
         let result = validate_restriction::<u64, u32, u32, u64>(&Restriction::None, &1u64, &Vec::new(), &Vec::new());
         assert!(result);
@@ -297,5 +301,10 @@ mod tests {
             &outputs,
         );
         assert!(!result);
+    }*/
+
+    #[test]
+    fn fake_test() {
+        assert(1 == 1)
     }
 }

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -65,7 +65,7 @@ where
                 return meta == Some(&metadata_value);
             } else {
                 return false;
-            } 
+            }
         }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -65,20 +65,7 @@ where
                 return meta == Some(&metadata_value);
             } else {
                 return false;
-            }
-
-            /*             for input in inputs {
-                let index_item = match &inputs[*input_index as usize] {
-                    Some(index) => index.metadata.get(&metadata_key) == &metadata_value,
-                    None => false,
-                };
-
-                if index_item != None {
-                    return true;
-                } else {
-                    false
-                }
-            } */
+            } 
         }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -13,6 +13,7 @@ pub enum Restriction {
     SenderOwnsAllInputs,
     FixedNumberOfInputs { num_inputs: u32 },
     FixedNumberOfOutputs { num_outputs: u32 },
+    FixedMetadataValue { input_index: u32, metadata_key: u32, metadata_value: u32 }
 }
 
 impl Default for Restriction {
@@ -37,6 +38,9 @@ where
         Restriction::None => true, // TODO implement some actual restrictions
         Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == num_inputs as usize,
         Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == num_outputs as usize,
+        Restriction::FixedMetadataValue { input_index, metadata_key, metadata_value} => {
+            return false;
+        }
         Restriction::SenderOwnsAllInputs => {
             for input in inputs {
                 let is_owned = match input.roles.get(&Default::default()) {

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -369,4 +369,116 @@ mod tests {
         );
         assert!(!result);
     }
+
+    #[test]
+    fn fixed_metadata_value_wrong_value_under_right_key_fail() {
+        let mut is_owner: BTreeMap<u32, u64> = BTreeMap::new();
+        is_owner.insert(Default::default(), 1u64);
+        let mut real_metadata = BTreeMap::new();
+        real_metadata.insert(2, 110);
+        let inputs = vec![
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: real_metadata,
+                parent_index: None,
+            },
+        ];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            &Restriction::FixedMetadataValue {
+                input_index: 2,
+                metadata_key: 2,
+                metadata_value: 45,
+            },
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn fixed_metadata_value_correct_value_under_incorrect_key_fail() {
+        let mut is_owner: BTreeMap<u32, u64> = BTreeMap::new();
+        is_owner.insert(Default::default(), 1u64);
+        let mut real_metadata = BTreeMap::new();
+        real_metadata.insert(1, 200);
+        real_metadata.insert(2, 110);
+        real_metadata.insert(3, 300);
+        let inputs = vec![
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: real_metadata,
+                parent_index: None,
+            },
+        ];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            &Restriction::FixedMetadataValue {
+                input_index: 2,
+                metadata_key: 3,
+                metadata_value: 110,
+            },
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn fixed_metadata_value_correct_value_under_correct_key_on_wrong_input_fail() {
+        let mut is_owner: BTreeMap<u32, u64> = BTreeMap::new();
+        is_owner.insert(Default::default(), 1u64);
+        let mut real_metadata = BTreeMap::new();
+        real_metadata.insert(1, 200);
+        real_metadata.insert(2, 110);
+        real_metadata.insert(3, 300);
+        let inputs = vec![
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: BTreeMap::new(),
+                parent_index: None,
+            },
+            ProcessIO {
+                roles: is_owner.clone(),
+                metadata: real_metadata,
+                parent_index: None,
+            },
+        ];
+        let result = validate_restriction::<u64, u32, u32, u64>(
+            &Restriction::FixedMetadataValue {
+                input_index: 1,
+                metadata_key: 2,
+                metadata_value: 110,
+            },
+            &1u64,
+            &inputs,
+            &Vec::new(),
+        );
+        assert!(!result);
+    }
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node-runtime'
-version = '2.5.0'
+version = '2.6.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '2.2.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '1.3.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '1.4.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 250,
+    spec_version: 260,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Uses an input value for the index as well as a TokenValueData and TokenValueKey to get the correct values. This has 2 tests and has been tested on Polkadot.

<img width="774" alt="Screenshot 2022-03-01 at 16 39 58" src="https://user-images.githubusercontent.com/35331926/156210868-50043319-bbd8-4313-b00a-9d4ac508f0b2.png">

