### PR TITLE
Fix bug which prevented the disabling of previous process versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7956,7 +7956,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.12.0"
+version = "2.12.1"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "vitalam-node-runtime"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.12.0'
+version = '2.12.1'
 
 [[bin]]
 name = 'vitalam-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-vitalam-node-runtime = { path = '../runtime', version = '2.6.0' }
+vitalam-node-runtime = { path = '../runtime', version = '2.6.1' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-process-validation'
-version = "1.4.0"
+version = "1.4.1"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/lib.rs
+++ b/pallets/process-validation/src/lib.rs
@@ -243,7 +243,7 @@ pub mod pallet {
                 Error::<T>::NonExistingProcess,
             );
             ensure!(<VersionModel<T>>::contains_key(&id), Error::<T>::InvalidVersion);
-            return match *version != <VersionModel<T>>::get(&id) {
+            return match *version > <VersionModel<T>>::get(&id) {
                 true => Err(Error::<T>::InvalidVersion),
                 false => Ok(()),
             };

--- a/pallets/process-validation/src/tests/disable_process.rs
+++ b/pallets/process-validation/src/tests/disable_process.rs
@@ -70,3 +70,30 @@ fn disables_process_and_dispatches_event() {
         assert_eq!(System::events()[0].event, expected);
     });
 }
+
+#[test]
+fn disables_process_and_dispatches_event_previous_version() {
+    new_test_ext().execute_with(|| {
+        System::set_block_number(1);
+        <VersionModel<Test>>::insert(PROCESS_ID, 2u32);
+        <ProcessModel<Test>>::insert(
+            PROCESS_ID,
+            1u32,
+            Process {
+                status: ProcessStatus::Enabled,
+                restrictions: [{ None }].to_vec(),
+            },
+        );
+        <ProcessModel<Test>>::insert(
+            PROCESS_ID,
+            2u32,
+            Process {
+                status: ProcessStatus::Enabled,
+                restrictions: [{ None }].to_vec(),
+            },
+        );
+        assert_ok!(ProcessValidation::disable_process(Origin::root(), PROCESS_ID, 1u32,));
+        let expected = Event::pallet_process_validation(ProcessDisabled(PROCESS_ID, 1));
+        assert_eq!(System::events()[0].event, expected);
+    });
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node-runtime'
-version = '2.6.0'
+version = '2.6.1'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '2.2.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '1.4.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '1.4.1', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 260,
+    spec_version: 261,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
### Steps to reproduce

1. bring up a local developer chain
2. create a process with some `id` for example `0x7465737400000000000000000000000000000000000000000000000000000000`. It doesn’t matter what restrictions are used. Ensure this is created with `version` `1`
3. create another process with the same `id`. Ensure this is created with `version` `2`
4. disable the process with the matching `id` and `version` `1`
5. Get the process for the `id` and `version` `1` from the `processModel`

### What I expect

The process to have a `state` of `Disabled`

### What actual happens

The process has a state of `Enabled`