### PR TITLE
Restrict a metadata value for an output to a fixed value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-process-validation"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7956,7 +7956,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "vitalam-node"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -7994,7 +7994,7 @@ dependencies = [
 
 [[package]]
 name = "vitalam-node-runtime"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "SenderOwnsAllInputs": "()",
       "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
       "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
-      "FixedInputMetadataValue": "FixedMetadataValueRestriction"
+      "FixedInputMetadataValue": "FixedMetadataValueRestriction",
+      "FixedOutputMetadataValue": "FixedMetadataValueRestriction"
     }
   },
   "FixedNumberOfInputsRestriction": {

--- a/README.md
+++ b/README.md
@@ -133,15 +133,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     }
   },
   "Role": {
-    "_enum": [
-      "Owner",
-      "Customer",
-      "AdditiveManufacturer",
-      "Laboratory",
-      "Buyer",
-      "Supplier",
-      "Reviewer"
-    ]
+    "_enum": ["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]
   },
   "ProcessIdentifier": "[u8; 32]",
   "ProcessVersion": "u32",
@@ -162,7 +154,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
       "SenderOwnsAllInputs": "()",
       "FixedNumberOfInputs": "FixedNumberOfInputsRestriction",
       "FixedNumberOfOutputs": "FixedNumberOfOutputsRestriction",
-      "FixedMetadataValue": "FixedMetadataValueRestriction"
+      "FixedInputMetadataValue": "FixedMetadataValueRestriction"
     }
   },
   "FixedNumberOfInputsRestriction": {
@@ -172,7 +164,7 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     "num_outputs": "u32"
   },
   "FixedMetadataValueRestriction": {
-    "input_index": "u32",
+    "index": "u32",
     "metadata_key": "TokenMetadataKey",
     "metadata_value": "TokenMetadataValue"
   },

--- a/README.md
+++ b/README.md
@@ -133,7 +133,15 @@ In order to use the API within `polkadot.js` you'll need to configure the follow
     }
   },
   "Role": {
-    "_enum": ["Owner", "Customer", "AdditiveManufacturer", "Laboratory", "Buyer", "Supplier", "Reviewer"]
+    "_enum": [
+      "Owner",
+      "Customer",
+      "AdditiveManufacturer",
+      "Laboratory",
+      "Buyer",
+      "Supplier",
+      "Reviewer"
+    ]
   },
   "ProcessIdentifier": "[u8; 32]",
   "ProcessVersion": "u32",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node'
-version = '2.12.0'
+version = '2.13.0'
 
 [[bin]]
 name = 'vitalam-node'
@@ -25,7 +25,7 @@ structopt = '0.3.8'
 hex-literal = "0.3.1"
 bs58 = "0.4.0"
 
-vitalam-node-runtime = { path = '../runtime', version = '2.6.0' }
+vitalam-node-runtime = { path = '../runtime', version = '2.7.0' }
 
 # Substrate dependencies
 frame-benchmarking = '3.0.0'

--- a/pallets/process-validation/Cargo.toml
+++ b/pallets/process-validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'pallet-process-validation'
-version = "1.4.0"
+version = "1.5.0"
 
 
 [package.metadata.docs.rs]

--- a/pallets/process-validation/src/restrictions.rs
+++ b/pallets/process-validation/src/restrictions.rs
@@ -21,8 +21,8 @@ where
     FixedNumberOfOutputs {
         num_outputs: u32,
     },
-    FixedMetadataValue {
-        input_index: u32,
+    FixedInputMetadataValue {
+        index: u32,
         metadata_key: TokenMetadataKey,
         metadata_value: TokenMetadataValue,
     },
@@ -54,12 +54,12 @@ where
         Restriction::<T, V>::None => true,
         Restriction::FixedNumberOfInputs { num_inputs } => return inputs.len() == num_inputs as usize,
         Restriction::FixedNumberOfOutputs { num_outputs } => return outputs.len() == num_outputs as usize,
-        Restriction::FixedMetadataValue {
-            input_index,
+        Restriction::FixedInputMetadataValue {
+            index,
             metadata_key,
             metadata_value,
         } => {
-            let selected_input = &inputs[input_index as usize];
+            let selected_input = &inputs[index as usize];
             let meta = selected_input.metadata.get(&metadata_key);
             meta == Some(&metadata_value)
         }
@@ -322,8 +322,8 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            Restriction::FixedMetadataValue {
-                input_index: 2,
+            Restriction::FixedInputMetadataValue {
+                index: 2,
                 metadata_key: 2,
                 metadata_value: 110,
             },
@@ -358,8 +358,8 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            Restriction::FixedMetadataValue {
-                input_index: 1,
+            Restriction::FixedInputMetadataValue {
+                index: 1,
                 metadata_key: 2,
                 metadata_value: 110,
             },
@@ -394,8 +394,8 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            Restriction::FixedMetadataValue {
-                input_index: 2,
+            Restriction::FixedInputMetadataValue {
+                index: 2,
                 metadata_key: 2,
                 metadata_value: 45,
             },
@@ -432,8 +432,8 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            Restriction::FixedMetadataValue {
-                input_index: 2,
+            Restriction::FixedInputMetadataValue {
+                index: 2,
                 metadata_key: 3,
                 metadata_value: 110,
             },
@@ -470,8 +470,8 @@ mod tests {
             },
         ];
         let result = validate_restriction::<u64, u32, u32, u64>(
-            Restriction::FixedMetadataValue {
-                input_index: 1,
+            Restriction::FixedInputMetadataValue {
+                index: 1,
                 metadata_key: 2,
                 metadata_value: 110,
             },

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -58,7 +58,7 @@ fn it_works_for_creating_token_with_file() {
 fn it_works_for_creating_token_with_literal() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let roles = (vec![(Default::default(), 1)]);
+        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),

--- a/pallets/simple-nft/src/tests.rs
+++ b/pallets/simple-nft/src/tests.rs
@@ -58,7 +58,7 @@ fn it_works_for_creating_token_with_file() {
 fn it_works_for_creating_token_with_literal() {
     new_test_ext().execute_with(|| {
         // create a token with no parents
-        let roles = BTreeMap::from_iter(vec![(Default::default(), 1)]);
+        let roles = (vec![(Default::default(), 1)]);
         let metadata = BTreeMap::from_iter(vec![(0, MetadataValue::Literal([0]))]);
         assert_ok!(SimpleNFTModule::run_process(
             Origin::signed(1),

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -4,7 +4,7 @@ edition = '2018'
 license = 'Apache-2.0'
 repository = 'https://github.com/digicatapult/vitalam-node/'
 name = 'vitalam-node-runtime'
-version = '2.6.0'
+version = '2.7.0'
 
 [package.metadata.docs.rs]
 targets = ['x86_64-unknown-linux-gnu']
@@ -26,7 +26,7 @@ serde = { features = ['derive'], optional = true, version = '1.0.101' }
 
 # local dependencies
 pallet-simple-nft = { version = '2.2.0', default-features = false, package = 'pallet-simple-nft', path = '../pallets/simple-nft' }
-pallet-process-validation = { version = '1.4.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
+pallet-process-validation = { version = '1.5.0', default-features = false, package = 'pallet-process-validation', path = '../pallets/process-validation' }
 pallet-symmetric-key = { version = '1.0.1', default-features = false, package = 'pallet-symmetric-key', path = '../pallets/symmetric-key' }
 frame-benchmarking = { default-features = false, optional = true, version = '3.0.0' }
 frame-executive = { default-features = false, version = '3.0.0' }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("vitalam-node"),
     impl_name: create_runtime_str!("vitalam-node"),
     authoring_version: 1,
-    spec_version: 260,
+    spec_version: 270,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Allow restriction on the value of a metadata item for an **output** at a specific index in the output `Vec`. This restriction is limited to a pre-specified value and cannot depend on other inputs or outputs.

In polkadot apps:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/40722025/156411773-736fd268-b40b-4a72-8bf5-f491b96c10f8.png">
